### PR TITLE
- Update config.py with real camera IPs (CAM-04, CAM-02, CAM-35),

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -13,27 +13,31 @@ class Settings(BaseSettings):
     DATABASE_URL: str = "postgresql://damanat:damanat@localhost:5432/damanat_db"
 
     # ── Network ───────────────────────────────────────────────────────────
-    BACKEND_IP: str = "192.168.1.50"
+    BACKEND_IP: str = "5.5.5.3"
     BACKEND_PORT: int = 8080
 
     # ── Security ──────────────────────────────────────────────────────────
     API_KEY: Optional[str] = None   # Set in .env to enable auth on API endpoints
 
     # ── Cameras ───────────────────────────────────────────────────────────
+    # Phase 1 — Active
     CAMERAS: dict = {
-        "CAM-01":    {"ip": "192.168.1.101", "user": "admin", "password": "CHANGE_ME", "phase": 1},
-        "CAM-02":    {"ip": "192.168.1.102", "user": "admin", "password": "CHANGE_ME", "phase": 1},
-        "CAM-03":    {"ip": "192.168.1.103", "user": "admin", "password": "CHANGE_ME", "phase": 1},
-        "CAM-ENTRY": {"ip": "192.168.1.104", "user": "admin", "password": "CHANGE_ME", "phase": 2, "gate": "entry"},
-        "CAM-EXIT":  {"ip": "192.168.1.105", "user": "admin", "password": "CHANGE_ME", "phase": 2, "gate": "exit"},
+        "CAM-04":  {"ip": "10.1.13.63", "user": "kloudspot", "password": "Kloud@123", "phase": 1, "name": "B1-PARKING"},
+        "CAM-02":  {"ip": "10.1.13.20", "user": "kloudspot", "password": "Kloud@123", "phase": 1, "name": "GF-WAITING"},
+        "CAM-35":  {"ip": "10.1.13.54", "user": "kloudspot", "password": "Kloud@123", "phase": 1, "name": "B1-DATA CENTER"},
+        # Phase 2 — Uncomment when ANPR cameras are installed
+        # "CAM-ENTRY": {"ip": "x.x.x.x", "user": "kloudspot", "password": "Kloud@123", "phase": 2, "gate": "entry"},
+        # "CAM-EXIT":  {"ip": "x.x.x.x", "user": "kloudspot", "password": "Kloud@123", "phase": 2, "gate": "exit"},
     }
 
     CAMERA_IP_MAP: dict = {
-        "192.168.1.101": "CAM-01",
-        "192.168.1.102": "CAM-02",
-        "192.168.1.103": "CAM-03",
-        "192.168.1.104": "CAM-ENTRY",
-        "192.168.1.105": "CAM-EXIT",
+        # Phase 1
+        "10.1.13.63": "CAM-04",
+        "10.1.13.20": "CAM-02",
+        "10.1.13.54": "CAM-35",
+        # Phase 2 — Uncomment when ANPR cameras are installed
+        # "x.x.x.x": "CAM-ENTRY",
+        # "x.x.x.x": "CAM-EXIT",
     }
 
     # ── Thresholds ────────────────────────────────────────────────────────

--- a/app/services/event_parser.py
+++ b/app/services/event_parser.py
@@ -50,11 +50,15 @@ def _parse_xml_event(raw_body: bytes, camera_ip: str) -> ParsedCameraEvent:
     root = ET.fromstring(xml_str)
 
     def find(tag):
-        el = root.find(f"{{{NS}}}{tag}") or root.find(tag)
+        el = root.find(f"{{{NS}}}{tag}")
+        if el is None:
+            el = root.find(tag)
         return el.text.strip() if el is not None and el.text else None
 
     def find_in(parent, tag):
-        el = parent.find(f"{{{NS}}}{tag}") or parent.find(tag)
+        el = parent.find(f"{{{NS}}}{tag}")
+        if el is None:
+            el = parent.find(tag)
         return el.text.strip() if el is not None and el.text else None
 
     trigger_time = datetime.utcnow()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,24 +1,24 @@
 # Web framework
-fastapi==0.110.0
-uvicorn[standard]==0.29.0
-starlette==0.36.3
-python-multipart==0.0.9
+fastapi==0.133.0
+uvicorn[standard]==0.41.0
+starlette==0.52.1
+python-multipart==0.0.22
 
 # Database
-sqlalchemy==2.0.28
-psycopg2-binary==2.9.9
-alembic==1.13.1
+sqlalchemy==2.0.47
+psycopg2-binary==2.9.11
+alembic==1.18.4
 
 # Config & validation
-pydantic==2.6.3
-pydantic-settings==2.2.1
-python-dotenv==1.0.1
+pydantic==2.12.5
+pydantic-settings==2.13.1
+python-dotenv==1.2.1
 
 # XML / HTTP
-lxml==5.1.0
-requests==2.31.0
-httpx==0.27.0
+lxml==6.0.2
+requests==2.32.5
+httpx==0.28.1
 
 # Testing
-pytest==8.1.0
-pytest-asyncio==0.23.5
+pytest==9.0.2
+pytest-asyncio==1.3.0

--- a/scripts/test/simulate_event.py
+++ b/scripts/test/simulate_event.py
@@ -6,7 +6,7 @@ import requests
 import json
 from datetime import datetime
 
-BACKEND_URL = "http://192.168.1.50:8080/api/v1/events/camera"
+BACKEND_URL = "http://localhost:8080/api/v1/events/camera"
 
 XML_TEMPLATES = {
     "fielddetection": """<?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
     credentials, and backend IP (5.5.5.3 VPN)
   - Comment out Phase 2 ANPR cameras (CAM-ENTRY/CAM-EXIT) for later
   - Fix XML Element parser bug: replace `or` with `is None` check (leaf XML elements are falsy in Python, causing event_type: unknown)
   - Update simulate_event.py backend URL to localhost
   - Add CLAUDE.md for Claude Code guidance