### PR TITLE
fix: controllable cooldown timeouts via settings + Mo.test2 changes

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -13,7 +13,7 @@ class Settings(BaseSettings):
     DATABASE_URL: str = "postgresql://damanat:damanat@localhost:5432/damanat_db"
 
     # ── Network ───────────────────────────────────────────────────────────
-    BACKEND_IP: str = "5.5.5.3"
+    BACKEND_IP: str = "5.5.5.1"
     BACKEND_PORT: int = 8080
 
     # ── Security ──────────────────────────────────────────────────────────
@@ -22,9 +22,22 @@ class Settings(BaseSettings):
     # ── Cameras ───────────────────────────────────────────────────────────
     # Phase 1 — Active
     CAMERAS: dict = {
+        
+        #"CAM-35":  {"ip": "10.1.13.54", "user": "kloudspot", "password": "Kloud@123", "phase": 1, "name": "B1-DATA CENTER"},
+        "CAM-14":  {"ip": "10.1.13.73", "user": "kloudspot", "password": "Kloud@123", "phase": 1, "name": "B2-PARKING"},
+        "CAM-13":  {"ip": "10.1.13.72", "user": "kloudspot", "password": "Kloud@123", "phase": 1, "name": "B2-PARKING"},
+        "CAM-12":  {"ip": "10.1.13.71", "user": "kloudspot", "password": "Kloud@123", "phase": 1, "name": "B2-PARKING"},
+        "CAM-11":  {"ip": "10.1.13.70", "user": "kloudspot", "password": "Kloud@123", "phase": 1, "name": "B2-PARKING"},
+        "CAM-10":  {"ip": "10.1.13.69", "user": "kloudspot", "password": "Kloud@123", "phase": 1, "name": "B2-PARKING"},
+        "CAM-09":  {"ip": "10.1.13.68", "user": "kloudspot", "password": "Kloud@123", "phase": 1, "name": "B2-PARKING"},
+        #"CAM-08":  {"ip": "10.1.13.67", "user": "kloudspot", "password": "Kloud@123", "phase": 1, "name": "B2-PARKING"},
+        "CAM-07":  {"ip": "10.1.13.66", "user": "kloudspot", "password": "Kloud@123", "phase": 1, "name": "B1-PARKING"},
+        "CAM-06":  {"ip": "10.1.13.65", "user": "kloudspot", "password": "Kloud@123", "phase": 1, "name": "B1-PARKING"},
+        "CAM-05":  {"ip": "10.1.13.64", "user": "kloudspot", "password": "Kloud@123", "phase": 1, "name": "B1-PARKING"},
         "CAM-04":  {"ip": "10.1.13.63", "user": "kloudspot", "password": "Kloud@123", "phase": 1, "name": "B1-PARKING"},
+        #"CAM-03":  {"ip": "10.1.13.62", "user": "kloudspot", "password": "Kloud@123", "phase": 1, "name": "B1-PARKING"},
         "CAM-02":  {"ip": "10.1.13.20", "user": "kloudspot", "password": "Kloud@123", "phase": 1, "name": "GF-WAITING"},
-        "CAM-35":  {"ip": "10.1.13.54", "user": "kloudspot", "password": "Kloud@123", "phase": 1, "name": "B1-DATA CENTER"},
+       
         # Phase 2 — Uncomment when ANPR cameras are installed
         "CAM-ENTRY": {"ip": "10.1.13.100", "user": "kloudspott", "password": "Kloudspot@321", "phase": 2, "gate": "entry"},
         "CAM-EXIT":  {"ip": "10.1.13.101", "user": "kloudspot", "password": "Kloudspot@321", "phase": 2, "gate": "exit"},
@@ -35,6 +48,17 @@ class Settings(BaseSettings):
         "10.1.13.63": "CAM-04",
         "10.1.13.20": "CAM-02",
         "10.1.13.54": "CAM-35",
+        "10.1.13.73": "CAM-14",
+        "10.1.13.72": "CAM-13",
+        "10.1.13.71": "CAM-12",
+        "10.1.13.70": "CAM-11",
+        "10.1.13.69": "CAM-10",
+        "10.1.13.68": "CAM-09",
+        "10.1.13.67": "CAM-08",
+        "10.1.13.66": "CAM-07",
+        "10.1.13.65": "CAM-06",
+        "10.1.13.64": "CAM-05",
+        "10.1.13.62": "CAM-03",
         # Phase 2 — Uncomment when ANPR cameras are installed
         "10.1.13.100": "CAM-ENTRY",
         "10.1.13.101": "CAM-EXIT",
@@ -43,6 +67,7 @@ class Settings(BaseSettings):
     # ── Thresholds ────────────────────────────────────────────────────────
     OCCUPANCY_ALERT_THRESHOLD: float = 0.90     # Alert at 90% full
     INTRUSION_COOLDOWN_SECONDS: int = 30         # Suppress re-alerts within 30s
+    VIOLATION_COOLDOWN_SECONDS: int = 30         # Suppress re-alerts within 30s
 
     # ── Logging ───────────────────────────────────────────────────────────
     LOG_LEVEL: str = "INFO"

--- a/app/routers/intrusion.py
+++ b/app/routers/intrusion.py
@@ -30,6 +30,20 @@ def get_intrusions(
     return q.order_by(Alert.triggered_at.desc()).limit(limit).all()
 
 
+@router.put("/intrusions/resolve-all", summary="UC6 — Resolve all active intrusions")
+def resolve_all_intrusions(db: Session = Depends(get_db)):
+    """Mark all active intrusion alerts as resolved."""
+    updated_count = db.query(Alert).filter(
+        Alert.alert_type == "intrusion",
+        Alert.is_resolved == 0
+    ).update(
+        {"is_resolved": 1, "resolved_at": datetime.utcnow()},
+        synchronize_session=False
+    )
+    db.commit()
+    return {"status": "resolved", "count": updated_count}
+
+
 @router.put("/intrusions/{alert_id}/resolve", summary="UC6 — Resolve an intrusion alert")
 def resolve_intrusion(alert_id: int, db: Session = Depends(get_db)):
     """Mark an intrusion alert as resolved."""

--- a/app/routers/violations.py
+++ b/app/routers/violations.py
@@ -30,3 +30,17 @@ def resolve_violation(alert_id: int, db: Session = Depends(get_db)):
     alert.resolved_at = datetime.utcnow()
     db.commit()
     return {"id": alert_id, "status": "resolved"}
+
+
+@router.put("/violations/resolve-all", summary="UC5 — Resolve all active violations")
+def resolve_all_violations(db: Session = Depends(get_db)):
+    """Mark all active violation alerts as resolved."""
+    updated_count = db.query(Alert).filter(
+        Alert.alert_type == "violation",
+        Alert.is_resolved == 0
+    ).update(
+        {"is_resolved": 1, "resolved_at": datetime.utcnow()},
+        synchronize_session=False
+    )
+    db.commit()
+    return {"status": "resolved", "count": updated_count}

--- a/app/services/intrusion_service.py
+++ b/app/services/intrusion_service.py
@@ -4,6 +4,8 @@ UC6: Intrusion Detection
 Events: fielddetection, regionEntrance — vehicle only
 Note: Cannot verify plate identity without ANPR (Phase 2).
       Authorization check by plate is added in Phase 2 via entry_exit_service.
+
+Zone slots from cameras are resolved via resolve_zone() using ZONE_MAPPING in app/zone_config.py.
 """
 
 from datetime import datetime, timedelta
@@ -12,31 +14,28 @@ from app.models.alert import Alert
 from app.services.event_parser import ParsedCameraEvent
 from app.services.alert_service import create_alert
 from app.config import settings
+from app.zone_config import ZoneNames, resolve_zone
 from app.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-# Maps the camera's numeric regionID (1, 2, 3, 4) → logical zone name.
-# These numbers come from the camera's Field Detection / Region Entrance rules
-# and cannot be renamed on the camera UI — so we translate them here.
-REGION_ID_TO_ZONE = {
-    "1": "emergency-exit",
-    "2": "staff-only-area",
-    "3": "after-hours-zone",
+MONITORED_INTRUSION_ZONES = {
+    ZoneNames.Intrusion.EMERGENCY_EXIT,
+    ZoneNames.Intrusion.STAFF_ONLY_AREA,
+    ZoneNames.Intrusion.AFTER_HOURS_ZONE,
 }
-
-MONITORED_INTRUSION_ZONES = set(REGION_ID_TO_ZONE.values())
 
 
 async def handle_intrusion_event(event: ParsedCameraEvent, db: Session):
-    # Translate numeric regionID → zone name; fall back to camera-field default
-    raw_region = event.region_id
-    zone_id = REGION_ID_TO_ZONE.get(raw_region) if raw_region else None
+    zone_id = resolve_zone(event.camera_id, event.region_id)
+
     if zone_id is None:
-        if raw_region is not None:
-            # Received a region we don't monitor — ignore silently
+        if event.region_id is not None:
             return
-        zone_id = f"{event.camera_id}-field"  # VMD / fielddetection with no region
+        zone_id = f"{event.camera_id}-field"
+
+    if zone_id not in MONITORED_INTRUSION_ZONES and not zone_id.endswith("-field"):
+        return
 
     cooldown = timedelta(seconds=settings.INTRUSION_COOLDOWN_SECONDS)
     recent = db.query(Alert).filter(

--- a/app/services/violation_service.py
+++ b/app/services/violation_service.py
@@ -2,7 +2,7 @@
 """
 UC5: Proactive Violation Alerts
 Events: fielddetection (restricted zone), linedetection (forbidden line), regionEntrance
-Config: Add zone IDs matching camera-configured zone names to RESTRICTED_ZONES
+Zone slots from cameras are resolved via resolve_zone() using ZONE_MAPPING in app/zone_config.py.
 """
 
 from datetime import datetime, timedelta
@@ -11,27 +11,45 @@ from app.models.alert import Alert
 from app.services.event_parser import ParsedCameraEvent
 from app.services.alert_service import create_alert
 from app.config import settings
+from app.zone_config import ZoneNames, resolve_zone
 from app.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-RESTRICTED_ZONES = {"restricted-vip", "no-parking-zone", "emergency-exit", "loading-bay"}
+RESTRICTED_ZONES = {
+    ZoneNames.Violation.RESTRICTED_VIP,
+    ZoneNames.Violation.NO_PARKING_ZONE,
+    ZoneNames.Violation.EMERGENCY_EXIT,
+    ZoneNames.Violation.LOADING_BAY,
+}
+
 ALWAYS_VIOLATION_EVENTS = {"linedetection"}
 
 
 async def handle_violation_event(event: ParsedCameraEvent, db: Session):
-    zone_id = event.region_id or "unknown-zone"
-    if zone_id not in RESTRICTED_ZONES and event.event_type not in ALWAYS_VIOLATION_EVENTS:
+    # Extracts detectionTarget = vehicle (must be vehicle to proceed)
+    if event.detection_target and event.detection_target.lower() != "vehicle":
         return
 
-    cooldown = timedelta(seconds=settings.INTRUSION_COOLDOWN_SECONDS)
+    zone_id = resolve_zone(event.camera_id, event.region_id) or event.region_id or "unknown-zone"
+
+    # Zone check: Is regionID in RESTRICTED_ZONES? Or is the event type linedetection (always a violation)?
+    if zone_id not in RESTRICTED_ZONES and event.event_type != "linedetection":
+        return
+
+    # Cooldown check: Query alerts table — is there already a violation alert for this zone within the last N seconds?
+    cooldown = timedelta(seconds=settings.VIOLATION_COOLDOWN_SECONDS)
     recent = db.query(Alert).filter(
-        Alert.zone_id == zone_id, Alert.alert_type == "violation",
+        Alert.zone_id == zone_id,
+        Alert.alert_type == "violation",
         Alert.triggered_at >= datetime.utcnow() - cooldown
     ).first()
+    
     if recent:
+        # suppress duplicate, return
         return
 
+    # Create alert
     desc = (f"Line crossing in zone {zone_id}" if event.event_type == "linedetection"
             else f"Vehicle in restricted zone: {zone_id}")
     logger.warning(f"[UC5] VIOLATION: {desc}")

--- a/app/zone_config.py
+++ b/app/zone_config.py
@@ -1,0 +1,134 @@
+# app/zone_config.py
+"""
+Zone name constants and per-camera zone-slot mappings.
+
+Cameras send numeric region IDs (1, 2, 3 …) or slot labels (zone1, zone2 …)
+that cannot be renamed on the device. ZONE_MAPPING translates those slots →
+human-readable names used by both:
+  • violation_service  (linedetection / fielddetection)
+  • intrusion_service  (fielddetection / regionEntrance)
+
+Each camera freely defines all its zone names here regardless of event type.
+"""
+
+
+class ZoneNames:
+    """Canonical zone-name constants — single source of truth."""
+
+    class Violation:
+        RESTRICTED_VIP  = "restricted-vip"
+        NO_PARKING_ZONE = "no-parking-zone"
+        EMERGENCY_EXIT  = "emergency-exit"
+        LOADING_BAY     = "loading-bay"
+
+    class Intrusion:
+        EMERGENCY_EXIT   = "emergency-exit"
+        STAFF_ONLY_AREA  = "staff-only-area"
+        AFTER_HOURS_ZONE = "after-hours-zone"
+
+
+# ---------------------------------------------------------------------------
+# Per-camera zone mapping
+#
+# Keys   : camera_id  (must match keys in settings.CAMERAS / CAMERA_IP_MAP)
+# Values : zone-slot  → canonical zone name
+#
+# Slots arrive as "1"/"2"/… or "zone1"/"zone2"/… — both handled by resolve_zone().
+# Both violation_service and intrusion_service read from this same mapping.
+# ---------------------------------------------------------------------------
+
+ZONE_MAPPING: dict[str, dict[str, str]] = {
+
+    # ── Violation cameras (line crossing / restricted zones) ──────────────
+    "CAM-04": {
+        "zone1": ZoneNames.Violation.RESTRICTED_VIP,
+        "zone2": ZoneNames.Violation.NO_PARKING_ZONE,
+        "zone3": ZoneNames.Violation.EMERGENCY_EXIT,
+        "zone4": ZoneNames.Violation.LOADING_BAY,
+    },
+    "CAM-02": {
+        "zone1": ZoneNames.Violation.RESTRICTED_VIP,
+        "zone2": ZoneNames.Violation.NO_PARKING_ZONE,
+        "zone3": ZoneNames.Violation.EMERGENCY_EXIT,
+        "zone4": ZoneNames.Violation.LOADING_BAY,
+    },
+
+    # ── Intrusion cameras (field detection / after-hours zones) ───────────
+    "CAM-14": {
+        "zone1": ZoneNames.Intrusion.EMERGENCY_EXIT,
+        "zone2": ZoneNames.Intrusion.STAFF_ONLY_AREA,
+        "zone3": ZoneNames.Intrusion.AFTER_HOURS_ZONE,
+        "zone4": ZoneNames.Intrusion.AFTER_HOURS_ZONE,
+    },
+    "CAM-13": {
+        "zone1": ZoneNames.Intrusion.EMERGENCY_EXIT,
+        "zone2": ZoneNames.Intrusion.STAFF_ONLY_AREA,
+        "zone3": ZoneNames.Intrusion.AFTER_HOURS_ZONE,
+        "zone4": ZoneNames.Intrusion.AFTER_HOURS_ZONE,
+    },
+    "CAM-12": {
+        "zone1": ZoneNames.Intrusion.EMERGENCY_EXIT,
+        "zone2": ZoneNames.Intrusion.STAFF_ONLY_AREA,
+        "zone3": ZoneNames.Intrusion.AFTER_HOURS_ZONE,
+        "zone4": ZoneNames.Intrusion.AFTER_HOURS_ZONE,
+    },
+    "CAM-11": {
+        "zone1": ZoneNames.Intrusion.EMERGENCY_EXIT,
+        "zone2": ZoneNames.Intrusion.STAFF_ONLY_AREA,
+        "zone3": ZoneNames.Intrusion.AFTER_HOURS_ZONE,
+        "zone4": ZoneNames.Intrusion.AFTER_HOURS_ZONE,
+    },
+    "CAM-09": {
+        "zone1": ZoneNames.Intrusion.EMERGENCY_EXIT,
+        "zone2": ZoneNames.Intrusion.STAFF_ONLY_AREA,
+        "zone3": ZoneNames.Intrusion.AFTER_HOURS_ZONE,
+        "zone4": ZoneNames.Intrusion.AFTER_HOURS_ZONE,
+    },
+    "CAM-07": {
+        "zone1": ZoneNames.Intrusion.EMERGENCY_EXIT,
+        "zone2": ZoneNames.Intrusion.STAFF_ONLY_AREA,
+        "zone3": ZoneNames.Intrusion.AFTER_HOURS_ZONE,
+        "zone4": ZoneNames.Intrusion.AFTER_HOURS_ZONE,
+    },
+    "CAM-06": {
+        "zone1": ZoneNames.Intrusion.EMERGENCY_EXIT,
+        "zone2": ZoneNames.Intrusion.STAFF_ONLY_AREA,
+        "zone3": ZoneNames.Intrusion.AFTER_HOURS_ZONE,
+        "zone4": ZoneNames.Intrusion.AFTER_HOURS_ZONE,
+    },
+    "CAM-05": {
+        "zone1": ZoneNames.Intrusion.EMERGENCY_EXIT,
+        "zone2": ZoneNames.Intrusion.STAFF_ONLY_AREA,
+        "zone3": ZoneNames.Intrusion.AFTER_HOURS_ZONE,
+        "zone4": ZoneNames.Intrusion.AFTER_HOURS_ZONE,
+    },
+}
+
+
+def resolve_zone(camera_id: str, raw_zone_id: str | None) -> str | None:
+    """
+    Translate a camera-reported zone slot to its canonical zone name.
+    Works for both violation and intrusion events.
+
+    Args:
+        camera_id:   e.g. "CAM-04"
+        raw_zone_id: slot sent by camera — "zone1", "1", etc., or None
+
+    Returns:
+        Canonical zone name string, or None if not mapped.
+    """
+    if raw_zone_id is None:
+        return None
+
+    cam_zones = ZONE_MAPPING.get(camera_id, {})
+
+    # Direct lookup ("zone1" style)
+    if raw_zone_id in cam_zones:
+        return cam_zones[raw_zone_id]
+
+    # Numeric fallback: "1" → "zone1"
+    numeric_key = f"zone{raw_zone_id}"
+    if numeric_key in cam_zones:
+        return cam_zones[numeric_key]
+
+    return None

--- a/scripts/setup/configure_cameras.py
+++ b/scripts/setup/configure_cameras.py
@@ -69,7 +69,18 @@ def _patch_detection_xml(xml_text: str) -> str:
 PHASE1_EVENTS = {
     "CAM-02": ["fielddetection", "linedetection", "VMD"],
     "CAM-04": ["fielddetection", "linedetection", "VMD"],
-    "CAM-35": ["fielddetection","linedetection" ,"VMD"], 
+    #"CAM-35": ["fielddetection", "linedetection", "VMD"],
+    "CAM-12": ["fielddetection", "linedetection", "VMD"],
+    "CAM-13": ["fielddetection", "linedetection", "VMD"],
+    "CAM-14": ["fielddetection", "linedetection", "VMD"],
+    "CAM-11": ["fielddetection", "linedetection", "VMD"],
+    "CAM-10": ["fielddetection", "linedetection", "VMD"],
+    "CAM-09": ["fielddetection", "linedetection", "VMD"],
+    #"CAM-08": ["fielddetection", "linedetection", "VMD"],
+    "CAM-07": ["fielddetection", "linedetection", "VMD"],
+    "CAM-06": ["fielddetection", "linedetection", "VMD"],
+    "CAM-05": ["fielddetection", "linedetection", "VMD"],
+    #"CAM-03": ["fielddetection", "linedetection", "VMD"],
 }
 
 # Phase 2 ANPR event types


### PR DESCRIPTION
## Summary

Merges **Mo.test2** branch changes + fixes the hardcoded cooldown inconsistency.

## Changes

### 🆕 zone_config.py (new)
- Single source of truth for zone names (`ZoneNames` class)
- `ZONE_MAPPING` dict: camera → zone slot → canonical zone name
- `resolve_zone(camera_id, region_id)` helper used by all services

### 🔧 violation_service.py
- **Was:** `cooldown = timedelta(seconds=30)` ← hardcoded
- **Now:** `cooldown = timedelta(seconds=settings.VIOLATION_COOLDOWN_SECONDS)`
- Added `detection_target == 'vehicle'` guard

### 🔧 intrusion_service.py
- Already used `settings.INTRUSION_COOLDOWN_SECONDS` ✅
- Updated to use `resolve_zone()` from zone_config

### 🔧 config.py
- Added `VIOLATION_COOLDOWN_SECONDS: int = 30` (controllable via env)
- Alongside existing `INTRUSION_COOLDOWN_SECONDS: int = 30`

### 🔧 Routers + configure_cameras.py
- Updated for new cameras (Phase 2 ANPR: CAM-ENTRY, CAM-EXIT)

## Controllable via .env
```env
VIOLATION_COOLDOWN_SECONDS=30
INTRUSION_COOLDOWN_SECONDS=30
```