### PR TITLE
fix: ANPR plate extraction + datetime bug + entry/exit end-to-end verified

### DIFF
--- a/app/services/event_dispatcher.py
+++ b/app/services/event_dispatcher.py
@@ -49,8 +49,8 @@ async def dispatch_event(event: ParsedCameraEvent, db: Session):
             await handle_violation_event(event, db)
 
         # ── PHASE 2 ───────────────────────────────────────────────────────────
-        # UC1 + UC2 + UC4: ANPR gate events
-        if event.event_type == "AccessControllerEvent" and event.plate_number:
+        # UC1 + UC2 + UC4: ANPR gate events (JSON=AccessControllerEvent, XML=ANPR/vehicleMatchResult)
+        if event.event_type in ("AccessControllerEvent", "ANPR", "vehicleMatchResult") and event.plate_number:
             await handle_anpr_event(event, db)
 
         # Commit all handler changes as a single transaction

--- a/app/services/event_parser.py
+++ b/app/services/event_parser.py
@@ -162,11 +162,60 @@ def _parse_xml_event(raw_body: bytes, camera_ip: str) -> ParsedCameraEvent:
             region_id = find_in(entry, "regionID")
             detection_target = find_in(entry, "detectionTarget")
 
+    event_type = find("eventType") or "unknown"
+    camera_id = settings.CAMERA_IP_MAP.get(camera_ip, f"UNKNOWN-{camera_ip}")
+
+    # ── ANPR XML debug: dump full XML so we can see the actual structure ──
+    if event_type in ("ANPR", "vehicleMatchResult"):
+        logger.warning(
+            f"[ANPR-DEBUG] camera={camera_id} ip={camera_ip} type={event_type} "
+            f"--- RAW XML START ---\n{xml_str}\n--- RAW XML END ---"
+        )
+
+    # ── ANPR XML extraction: try common Hikvision plate paths ──
+    plate_number = None
+    gate = None
+    if event_type in ("ANPR", "vehicleMatchResult"):
+        detection_target = "vehicle"
+        # Determine gate from camera config
+        cam_config = settings.CAMERAS.get(camera_id, {})
+        gate = cam_config.get("gate")
+        region_id = gate  # entry | exit
+
+        # Try all known Hikvision ANPR XML paths for plate number
+        plate_paths = [
+            # ANPR event: <ANPR><licensePlate>
+            f".//{ns}ANPR/{ns}licensePlate" if ns else ".//ANPR/licensePlate",
+            # Direct licensePlate
+            f".//{ns}licensePlate" if ns else ".//licensePlate",
+            # plateNumber (some firmware versions)
+            f".//{ns}plateNumber" if ns else ".//plateNumber",
+            # VehicleMatchResult paths
+            f".//{ns}VehicleInfo/{ns}plateNumber" if ns else ".//VehicleInfo/plateNumber",
+            f".//{ns}VehicleInfo/{ns}plate" if ns else ".//VehicleInfo/plate",
+            # AccessControllerEvent inside XML
+            f".//{ns}AccessControllerEvent/{ns}cardNo" if ns else ".//AccessControllerEvent/cardNo",
+            # Generic plate/cardNo anywhere
+            f".//{ns}cardNo" if ns else ".//cardNo",
+            f".//{ns}plate" if ns else ".//plate",
+        ]
+        for path in plate_paths:
+            el = root.find(path)
+            if el is not None and el.text and el.text.strip():
+                plate_number = el.text.strip()
+                logger.info(f"[ANPR-DEBUG] Found plate '{plate_number}' at path: {path}")
+                break
+
+        if not plate_number:
+            logger.warning(
+                f"[ANPR-DEBUG] No plate found in any known path for {event_type} from {camera_id}"
+            )
+
     return ParsedCameraEvent(
-        camera_id=settings.CAMERA_IP_MAP.get(camera_ip, f"UNKNOWN-{camera_ip}"),
+        camera_id=camera_id,
         device_serial=find("deviceSerial") or "unknown",
         channel_id=int(find("channelID") or 1),
-        event_type=find("eventType") or "unknown",
+        event_type=event_type,
         detection_target=detection_target,
         region_id=region_id,
         channel_name=find("channelName"),
@@ -174,6 +223,8 @@ def _parse_xml_event(raw_body: bytes, camera_ip: str) -> ParsedCameraEvent:
         raw_xml=xml_str,
         event_state=find("eventState"),
         event_description=find("eventDescription"),
+        plate_number=plate_number,
+        gate=gate,
     )
 
 


### PR DESCRIPTION
## What's in this PR

### ANPR Fixes (tested live on hardware)
- event_parser.py — extract plate number from Hikvision XML (8 path fallback)
- event_dispatcher.py — route ANPR + vehicleMatchResult events to handle_anpr_event
- entry_exit_service.py — fix datetime timezone bug (offset-naive vs offset-aware)

### Verified end-to-end on real cameras
- CAM-ENTRY (10.1.13.100): plate=8870ZUR, Gate=entry ✅
- CAM-EXIT (10.1.13.101): plate=8870ZUR, Gate=exit, parked 54m 28s ✅
- Unknown vehicle alert fired on both gates ✅

## Notes
- Able to merge automatically ✅