### PR TITLE
feat: serve detection snapshots and emit full URLs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -50,6 +50,12 @@ class Settings(BaseSettings):
     BACKEND_IP: str = "127.0.0.1"  # override via .env per deployment
     BACKEND_PORT: int = 8080
 
+    # Externally-reachable origin used to build full snapshot URLs.
+    # Snapshots are written into detection_images/ and served by the
+    # /snapshots StaticFiles mount; consumers store the full URL form
+    # (e.g. http://pms-ai:8080/snapshots/foo.jpg) directly in the DB.
+    PUBLIC_BASE_URL: str = "http://localhost:8080"
+
     # ── Security ──────────────────────────────────────────────────────────
     API_KEY: Optional[str] = None   # Set in .env to enable auth on API endpoints
 

--- a/app/main.py
+++ b/app/main.py
@@ -4,16 +4,20 @@ FastAPI application entry point.
 Includes security middleware, global error handlers, and all routers.
 """
 
+from pathlib import Path
+
 from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 from app.routers import (
     events, occupancy,
     health, alerts, vehicles, entry_exit, parking_stats, parking_sessions_internal,
 )
-from app.database import create_tables 
+from app.database import create_tables
 from app.config import settings
+from app.services.snapshot_service import SNAPSHOT_DIR
 from app.utils.logger import get_logger
 import time
 
@@ -57,6 +61,17 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
 
 if settings.API_KEY:
     app.add_middleware(APIKeyMiddleware)
+
+# ── Static snapshot serving ──────────────────────────────────────────────
+# Expose detection_images/ over HTTP so consumers (frontend / API gateway)
+# can fetch the JPEGs that get referenced by snapshot_path columns.
+_snapshots_dir = Path(SNAPSHOT_DIR)
+_snapshots_dir.mkdir(exist_ok=True)
+app.mount(
+    "/snapshots",
+    StaticFiles(directory=_snapshots_dir, check_dir=False),
+    name="snapshots",
+)
 
 # ── Request Timing & Logging Middleware ──────────────────────────────────────
 @app.middleware("http")

--- a/app/services/event_dispatcher.py
+++ b/app/services/event_dispatcher.py
@@ -32,17 +32,14 @@ async def dispatch_event(event: ParsedCameraEvent, db: Session) -> dict:
         "AccessControllerEvent", "vehicleMatchResult", "ANPR",
     )
     if event.event_type in SNAPSHOT_EVENT_TYPES:
-        # Preserve the original local file path (always local now)
-        if event.snapshot_path:
-            event.local_snapshot_path = event.snapshot_path
-
-        # If no multipart image was attached, try fetching a fresh snapshot from the camera
+        # event_parser.parse_camera_event already sets snapshot_path (URL) and
+        # local_snapshot_path on multipart events. If neither is set, fall
+        # back to fetching a fresh JPEG from the camera here.
         if not event.snapshot_path:
             try:
                 fresh = await fetch_snapshot(event.camera_id, event.event_type)
                 if fresh:
-                    event.snapshot_path = fresh
-                    event.local_snapshot_path = fresh
+                    event.snapshot_path, event.local_snapshot_path = fresh
             except Exception as e:
                 logger.warning(f"Snapshot fetch failed for {event.camera_id}: {e}")
 

--- a/app/services/event_parser.py
+++ b/app/services/event_parser.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from datetime import datetime, UTC
 from typing import Optional, List, Dict
 from app.config import settings
+from app.services.snapshot_service import to_public_snapshot_url
 from app.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -164,9 +165,14 @@ def parse_camera_event(raw_body: bytes, camera_ip: str, content_type: str = "") 
                 snapshot_path = correct_filename
             except Exception as e:
                 logger.warning(f"Could not rename multipart image from {snapshot_path}: {e}")
-        
-        event.snapshot_path = snapshot_path
-    
+
+        # snapshot_path on the event is the publicly-fetchable URL — that's
+        # what gets persisted into entry_exit_log / parking_sessions / alerts.
+        # local_snapshot_path keeps the on-disk filename so downstream code
+        # (e.g. PMS tracking API forwarding) can read the file directly.
+        event.local_snapshot_path = snapshot_path
+        event.snapshot_path = to_public_snapshot_url(snapshot_path)
+
     return event
 
 

--- a/app/services/snapshot_service.py
+++ b/app/services/snapshot_service.py
@@ -5,7 +5,10 @@ immediately after a detection event fires.
 
 Endpoint: GET http://{cam_ip}/ISAPI/Streaming/channels/1/picture
 
-Storage: always saves to detection_images/ on disk, returns local file path.
+Storage: always saves to detection_images/ on disk. Returns a tuple of
+`(public_url, local_path)` so callers can put the URL into the DB while
+keeping the on-disk path for local processing (e.g. forwarding to the
+PMS tracking API).
 """
 
 import httpx
@@ -22,10 +25,24 @@ SNAPSHOT_PATH = "/ISAPI/Streaming/channels/1/picture"
 os.makedirs(SNAPSHOT_DIR, exist_ok=True)
 
 
-async def fetch_snapshot(camera_id: str, event_type: str) -> str | None:
+def to_public_snapshot_url(local_path: str | None) -> str | None:
+    """Convert a local snapshot filesystem path (or just a filename) into the
+    full public URL served by the /snapshots StaticFiles mount.
+
+    Returns None for empty input. Drops directory components — only the
+    filename matters because /snapshots is rooted at SNAPSHOT_DIR.
     """
-    Fetch a snapshot from the camera and save it locally.
-    Returns the local file path, or None on failure.
+    if not local_path:
+        return None
+    filename = os.path.basename(local_path)
+    base = (settings.PUBLIC_BASE_URL or "").rstrip("/")
+    return f"{base}/snapshots/{filename}" if base else f"/snapshots/{filename}"
+
+
+async def fetch_snapshot(camera_id: str, event_type: str) -> tuple[str, str] | None:
+    """Fetch a JPEG from the camera and save it locally.
+
+    Returns ``(public_url, local_path)`` on success, ``None`` on failure.
     """
     cam = settings.CAMERAS.get(camera_id)
     if not cam:
@@ -53,7 +70,7 @@ async def fetch_snapshot(camera_id: str, event_type: str) -> str | None:
             f.write(image_bytes)
         logger.info(f"[SNAPSHOT] Saved locally → {filepath}")
 
-        return filepath
+        return to_public_snapshot_url(filepath), filepath
 
     except Exception as e:
         logger.error(f"[SNAPSHOT] Failed for {camera_id}: {e}")


### PR DESCRIPTION
## Summary

Snapshot fields persisted in `entry_exit_log`, `parking_sessions` and `alerts` now hold full URLs (`http://<host>/snapshots/<file>.jpg`) instead of local relative paths. Downstream consumers (API-Gateway, frontend) no longer need to rewrite the value — it lands in the DB ready to fetch.

## Changes

- `app/main.py` mounts `StaticFiles(detection_images/)` at `/snapshots`, so the JPEGs PMS-AI writes are reachable over HTTP at `<PUBLIC_BASE_URL>/snapshots/<file>`.
- `app/services/snapshot_service.py` — new `to_public_snapshot_url(local_path)` helper. `fetch_snapshot()` now returns `(public_url, local_path)` so callers can store the URL in the DB while keeping the on-disk path for local processing (PMS tracking forwarder).
- `app/services/event_parser.py:parse_camera_event` splits the two: `event.snapshot_path` is the URL (→ DB), `event.local_snapshot_path` is the on-disk filename (→ tracking forwarder).
- `app/services/event_dispatcher.py` unpacks the new tuple from `fetch_snapshot`. The previous `local_snapshot_path = snapshot_path` copy is gone — both fields are populated explicitly at their source.
- `app/config.py` adds `PUBLIC_BASE_URL`, default `http://localhost:8080` for dev. Production must override with the externally-reachable origin.

## Deployment

Set `PUBLIC_BASE_URL=https://<pms-ai-host>` per environment. Mount a persistent volume at the working-dir-relative `detection_images/` so snapshots survive container restarts.

## Test plan

- [ ] `python -c "from app.services.snapshot_service import to_public_snapshot_url; print(to_public_snapshot_url('detection_images/foo.jpg'))"` returns `http://localhost:8080/snapshots/foo.jpg`
- [ ] Start the service; `curl -I http://localhost:8080/snapshots/<a-real-file>.jpg` returns 200
- [ ] Trigger an ANPR event and verify the new row in `entry_exit_log.snapshot_path` (and the corresponding `parking_sessions.entry_snapshot_path`) is a full URL, not a `detection_images/...` local path
- [ ] Confirm `event.local_snapshot_path` still flows to `core_backend_client.notify_pms_anpr` so the tracking forwarder still reads from disk (no regression in existing behaviour)

## Notes for reviewers

The diff stat looks larger than the substantive changes because some files in `develop` HEAD have mixed CRLF/LF line endings; staging on Windows triggers a small EOL normalisation per file. Use GitHub's "Hide whitespace" view, or run `git diff --ignore-cr-at-eol`, to see the actual content changes (57 insertions, 16 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)