### PR TITLE
feat: track current slot on the vehicle row

### DIFF
--- a/alembic/versions/c1d2e3f4a5b6_vehicles_add_current_slot_id.py
+++ b/alembic/versions/c1d2e3f4a5b6_vehicles_add_current_slot_id.py
@@ -1,0 +1,41 @@
+"""vehicles_add_current_slot_id
+
+Revision ID: c1d2e3f4a5b6
+Revises: 7a8b9c0d1e2f
+Create Date: 2026-04-30 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c1d2e3f4a5b6'
+down_revision: Union[str, Sequence[str], None] = '7a8b9c0d1e2f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add vehicles.current_slot_id — the slot the vehicle is currently
+    occupying, kept in sync by parking_session_service.bind_slot /
+    unbind_slot. Mirrors the varchar key shape already used by
+    parking_sessions.slot_id (e.g. 'B1_CRO'), so the value matches
+    parking_slots.slot_id directly."""
+    op.add_column(
+        'vehicles',
+        sa.Column('current_slot_id', sa.String(length=50), nullable=True),
+    )
+    op.create_index(
+        'ix_vehicles_current_slot_id',
+        'vehicles',
+        ['current_slot_id'],
+    )
+
+
+def downgrade() -> None:
+    """Drop the index and column."""
+    op.drop_index('ix_vehicles_current_slot_id', table_name='vehicles')
+    op.drop_column('vehicles', 'current_slot_id')

--- a/app/models/vehicle.py
+++ b/app/models/vehicle.py
@@ -26,5 +26,10 @@ class Vehicle(Base):
     registered_at = Column(DateTime)
     notes = Column(Text)
 
+    # Set by parking_session_service.bind_slot when VA reports the vehicle
+    # parked in a slot, cleared by unbind_slot when it leaves. Matches the
+    # varchar slot_id used in parking_sessions / parking_slots / slot_status.
+    current_slot_id = Column(String(50), index=True)
+
     def __repr__(self):
         return f"<Vehicle {self.plate_number} owner={self.owner_name} type={self.vehicle_type}>"

--- a/app/services/parking_session_service.py
+++ b/app/services/parking_session_service.py
@@ -22,6 +22,22 @@ def _naive(dt: Optional[datetime]) -> datetime:
     return value
 
 
+def _resolve_vehicle(db: Session, session: ParkingSession) -> Optional[Vehicle]:
+    """Find the Vehicle row referenced by a parking session.
+
+    Prefers `session.vehicle_id` when set; falls back to plate-matching
+    for legacy sessions written before the FK was always populated.
+    Returns None if no matching vehicle exists.
+    """
+    if session.vehicle_id:
+        v = db.query(Vehicle).filter(Vehicle.id == session.vehicle_id).first()
+        if v:
+            return v
+    if session.plate_number:
+        return db.query(Vehicle).filter(Vehicle.plate_number == session.plate_number).first()
+    return None
+
+
 def get_latest_open_session(db: Session, plate_number: str) -> Optional[ParkingSession]:
     return (
         db.query(ParkingSession)
@@ -116,6 +132,14 @@ def bind_slot(
     if snapshot_path:
         session.slot_snapshot_path = snapshot_path
     session.updated_at = datetime.now(UTC)
+
+    # Mirror the slot binding onto the vehicle row so callers that only
+    # have the Vehicle (not the open session) can still answer
+    # "where is this vehicle right now?".
+    vehicle = _resolve_vehicle(db, session)
+    if vehicle is not None:
+        vehicle.current_slot_id = slot_id
+
     db.flush()
     return session
 
@@ -146,6 +170,14 @@ def unbind_slot(
     if snapshot_path:
         session.slot_snapshot_path = snapshot_path
     session.updated_at = datetime.now(UTC)
+
+    # Clear the slot binding on the vehicle, but only if it still points
+    # at the slot we're unbinding — otherwise we'd clobber a concurrent
+    # bind that already moved the vehicle to another slot.
+    vehicle = _resolve_vehicle(db, session)
+    if vehicle is not None and vehicle.current_slot_id == session.slot_id:
+        vehicle.current_slot_id = None
+
     db.flush()
     return session
 


### PR DESCRIPTION
## Summary

Adds `vehicles.current_slot_id` and keeps it in sync with bind/unbind events that VideoAnalytics fires through `/api/v1/internal/parking-sessions/{bind,unbind}-slot`. Callers that only have the `Vehicle` row (not its open `parking_session`) can now answer "where is this vehicle right now?" with a single column read instead of joining through `parking_sessions`.

Resolves the gap described in the gateway: VA's slot-occupancy update propagates to `parking_sessions.slot_id` and to `slot_status.plate_number`, but the `vehicles` row carried no slot reference at all.

## Changes

- **alembic `c1d2e3f4a5b6_vehicles_add_current_slot_id`** — adds nullable `current_slot_id VARCHAR(50)` to `vehicles` plus index `ix_vehicles_current_slot_id`. Down-revision off the current head `7a8b9c0d1e2f`.
- **`app/models/vehicle.py`** — declares the new column. Same shape as `parking_sessions.slot_id` (varchar 50), so the value matches `parking_slots.slot_id` directly (e.g. `B1_CRO`).
- **`app/services/parking_session_service.py`**
  - new `_resolve_vehicle(db, session)` helper — uses `session.vehicle_id` when set, falls back to plate match for legacy sessions where `vehicle_id` is NULL.
  - `bind_slot`: after updating the parking session, also sets the resolved vehicle's `current_slot_id` to the bound slot.
  - `unbind_slot`: clears `current_slot_id` **only if it still points at the slot we're unbinding** — prevents clobbering a concurrent bind that may have already moved the vehicle to another slot.

## Backward compat

- Column is nullable with no server default — existing rows keep `NULL` until their next bind. No backfill required.
- No change to bind/unbind request schemas; only PMS-AI-internal behaviour.

## Test plan

- [ ] Run the alembic migration (`alembic upgrade head`); verify `vehicles.current_slot_id` exists and is nullable.
- [ ] Trigger a slot bind via VA (`POST /api/v1/internal/parking-sessions/bind-slot` with a known plate) → query `SELECT current_slot_id FROM vehicles WHERE plate_number = '<plate>'` → matches the bound slot.
- [ ] Trigger an unbind for the same plate/slot → `current_slot_id` is `NULL`.
- [ ] Trigger an unbind on a different slot than what the vehicle is bound to → `current_slot_id` is left alone (concurrent-move safety).
- [ ] Trigger a bind for a plate whose `vehicle_id` is NULL on the session row but whose `plate_number` matches a row in `vehicles` → fallback path resolves the vehicle and updates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)