### PR TITLE
refactor: serve snapshots via a regular GET endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,20 +4,17 @@ FastAPI application entry point.
 Includes security middleware, global error handlers, and all routers.
 """
 
-from pathlib import Path
-
 from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 from app.routers import (
     events, occupancy,
     health, alerts, vehicles, entry_exit, parking_stats, parking_sessions_internal,
+    snapshots,
 )
 from app.database import create_tables
 from app.config import settings
-from app.services.snapshot_service import SNAPSHOT_DIR
 from app.utils.logger import get_logger
 import time
 
@@ -62,17 +59,6 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
 if settings.API_KEY:
     app.add_middleware(APIKeyMiddleware)
 
-# ── Static snapshot serving ──────────────────────────────────────────────
-# Expose detection_images/ over HTTP so consumers (frontend / API gateway)
-# can fetch the JPEGs that get referenced by snapshot_path columns.
-_snapshots_dir = Path(SNAPSHOT_DIR)
-_snapshots_dir.mkdir(exist_ok=True)
-app.mount(
-    "/pms-ai/snapshots",
-    StaticFiles(directory=_snapshots_dir, check_dir=False),
-    name="snapshots",
-)
-
 # ── Request Timing & Logging Middleware ──────────────────────────────────────
 @app.middleware("http")
 async def log_requests(request: Request, call_next):
@@ -109,6 +95,8 @@ app.include_router(parking_stats.router, prefix="/api/v1", tags=["📊 Stats —
 app.include_router(vehicles.router,      prefix="/api/v1", tags=["🔍 Vehicles — UC4"])
 
 app.include_router(parking_sessions_internal.router, prefix="/api/v1", tags=["Internal Sessions"])
+
+app.include_router(snapshots.router, tags=["📸 Snapshots"])
 
 import asyncio
 from app.database import SessionLocal

--- a/app/routers/snapshots.py
+++ b/app/routers/snapshots.py
@@ -1,0 +1,36 @@
+# app/routers/snapshots.py
+"""
+Serves saved camera snapshot JPEGs from the local detection_images/ folder.
+
+Replaces the previous StaticFiles mount with a regular GET endpoint so we
+can validate filenames and have a normal place to add logging or swap the
+storage backend later.
+"""
+
+import os
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse
+
+from app.services.snapshot_service import SNAPSHOT_DIR
+
+router = APIRouter()
+
+
+@router.get(
+    "/pms-ai/snapshots/{filename}",
+    summary="Serve a saved camera snapshot JPEG",
+    response_class=FileResponse,
+)
+def get_snapshot(filename: str):
+    # Reject anything that isn't a bare filename — blocks ../ traversal,
+    # absolute paths, and Windows drive specs.
+    safe_name = os.path.basename(filename)
+    if not safe_name or safe_name != filename:
+        raise HTTPException(status_code=404, detail="Snapshot not found")
+
+    filepath = os.path.join(SNAPSHOT_DIR, safe_name)
+    if not os.path.isfile(filepath):
+        raise HTTPException(status_code=404, detail="Snapshot not found")
+
+    return FileResponse(filepath, media_type="image/jpeg")


### PR DESCRIPTION
## Summary
- Replace the `app.mount("/pms-ai/snapshots", StaticFiles(...))` block in `app/main.py` with a normal FastAPI router at `app/routers/snapshots.py` that returns the JPEG via `FileResponse(media_type="image/jpeg")`.
- Public URL is unchanged (`/pms-ai/snapshots/{filename}`), so every existing `snapshot_path` value already saved in the database keeps resolving and `to_public_snapshot_url()` keeps emitting the right URL.
- The new endpoint adds an explicit `os.path.basename` + equality check to reject path-traversal attempts that the `StaticFiles` mount happened to filter for us, and it sits inside the normal router list so the request-logging middleware sees it like any other route.
- `detection_images/` is still created on app boot — `app/services/snapshot_service.py` already runs `os.makedirs(SNAPSHOT_DIR, exist_ok=True)` at import time, so the `mkdir` removed from `main.py` is not lost.

## Test plan
- [x] `uvicorn app.main:app --port 8090` boots clean; `app.routes` includes `/pms-ai/snapshots/{filename}`.
- [x] `GET /pms-ai/snapshots/<existing>.jpg` → `HTTP 200`, `content-type: image/jpeg`, valid JPEG bytes returned (verified against `snap_AccessControllerEvent_CAM-ENTRY_20260311_033041_162760.jpg`, 986,700 bytes, 2688×1552).
- [x] `GET /pms-ai/snapshots/does-not-exist.jpg` → `HTTP 404`.
- [x] `GET /pms-ai/snapshots/..%2F..%2Fapp%2Fmain.py` → `HTTP 404` (no source leak).
- [ ] Verify in the wider stack: trigger an event that produces a snapshot, then GET the alert from `/api/v1/alerts` and follow the `snapshot_path` URL it returns — it should render the JPEG.
- [ ] If `API_KEY` is set in `.env`: confirm `/pms-ai/snapshots/<file>.jpg` without `X-API-Key` returns `401` (matches the prior StaticFiles behaviour, since `/pms-ai/snapshots/...` is not in the `open_paths` whitelist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)