### PR TITLE
Lifecycle hardening: bind/unbind/close + TZ + alert slot fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,20 @@ VIOLATION_COOLDOWN_SECONDS=30
 INTRUSION_COOLDOWN_SECONDS=30
 OCCUPANCY_ALERT_THRESHOLD=0.90
 
+# ── Facility timezone (must match the Gateway) ──────────────────────────────
+# Offset from UTC for "today" / "since-local-midnight" math. The Gateway also
+# reads this; both services must use the SAME value or per-service "today"
+# windows disagree.
+#   Saudi Arabia / Riyadh:        3.0  (no DST)
+#   Egypt:                        2.0  (note: DST changes seasonally)
+#   Cameras report local time
+#   without a Z suffix:           0.0  (treat the DB as already facility-local)
+#
+# Verify: capture one Hikvision webhook payload and inspect <dateTime>. If it
+# ends in `Z`, set offset to match the facility wall clock. If no TZ suffix,
+# the DB stores facility-local pretending to be UTC — set offset to 0.0.
+FACILITY_TIMEZONE_OFFSET_HOURS=3.0
+
 # ── Phase 2 Cameras (ANPR — entry/exit gates) ───────────────────────────────
 CAM_ENTRY_IP=10.1.13.100
 CAM_ENTRY_USER=admin

--- a/app/config.py
+++ b/app/config.py
@@ -292,6 +292,14 @@ class Settings(BaseSettings):
     # ── Thresholds ────────────────────────────────────────────────────────
     OCCUPANCY_ALERT_THRESHOLD: float = 0.90
     DEFAULT_ZONE_CAPACITY: int = 9
+
+    # ── Facility timezone (must match the Gateway) ───────────────────────
+    # Offset from UTC for "today"/"since-local-midnight" math. The Gateway
+    # carries the same env var; both services must use the same value or
+    # per-service "today" windows diverge. See Damanat PMS Cameras audit
+    # `HIGH_SEVERITY_FIX_PLAN.md` Fix #2 for the operational caveat about
+    # Hikvision camera clocks and when 0.0 is the right value.
+    FACILITY_TIMEZONE_OFFSET_HOURS: float = 3.0
     
     # False Exit Prevention (Bug #23)
     EXIT_CONFIRM_SECONDS: int = 5
@@ -340,4 +348,52 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+
+# ── Facility-local "today" helpers ─────────────────────────────────────────
+# Mirrors the Gateway's `app/config.py:facility_tz()` / `facility_today_utc()`
+# so PMS-AI's `/api/v1/entry-exit/count/today` and `/api/v1/stats/*` use the
+# same window the dashboard shows. Import via:
+#     from app.config import settings, facility_today_utc
+def facility_tz():
+    """The local timezone for "today"-style date math. Configured via
+    FACILITY_TIMEZONE_OFFSET_HOURS env var (default 3.0 = UTC+3, Saudi Arabia).
+    DB columns are stored as UTC-naive; this offset only affects boundary
+    calculations like "since local midnight today"."""
+    from datetime import timezone, timedelta
+    return timezone(timedelta(hours=settings.FACILITY_TIMEZONE_OFFSET_HOURS))
+
+
+def facility_today_utc():
+    """Naive UTC datetime of facility-local midnight today. Use this when
+    filtering DB columns stored as UTC-naive datetimes against "since local
+    midnight today" — pair with `facility_tomorrow_utc()` for an exclusive
+    upper bound."""
+    from datetime import datetime, timezone
+    now_local = datetime.now(facility_tz())
+    midnight_local = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+    return midnight_local.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+def facility_tomorrow_utc():
+    """Naive UTC datetime of facility-local midnight at the END of today
+    (start of tomorrow). Pairs with facility_today_utc() for range filters."""
+    from datetime import timedelta
+    return facility_today_utc() + timedelta(days=1)
+
+
+def facility_day_range_utc(target_date_str: str | None = None):
+    """Return (start_utc, end_utc) range for a facility-local day. If
+    target_date_str is None, uses today. Pass a string like "2026-04-13" to
+    get any date's window. Both bounds are naive UTC datetimes suitable for
+    filtering DB columns stored as UTC-naive."""
+    from datetime import datetime, timezone, date as date_cls, timedelta
+    if target_date_str is None:
+        start = facility_today_utc()
+    else:
+        d = date_cls.fromisoformat(target_date_str)
+        start_local = datetime(d.year, d.month, d.day, tzinfo=facility_tz())
+        start = start_local.astimezone(timezone.utc).replace(tzinfo=None)
+    end = start + timedelta(days=1)
+    return start, end
 

--- a/app/main.py
+++ b/app/main.py
@@ -4,20 +4,17 @@ FastAPI application entry point.
 Includes security middleware, global error handlers, and all routers.
 """
 
-from pathlib import Path
-
 from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 from app.routers import (
     events, occupancy,
     health, alerts, vehicles, entry_exit, parking_stats, parking_sessions_internal,
+    snapshots,
 )
 from app.database import create_tables
 from app.config import settings
-from app.services.snapshot_service import SNAPSHOT_DIR
 from app.utils.logger import get_logger
 import time
 
@@ -62,17 +59,6 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
 if settings.API_KEY:
     app.add_middleware(APIKeyMiddleware)
 
-# ── Static snapshot serving ──────────────────────────────────────────────
-# Expose detection_images/ over HTTP so consumers (frontend / API gateway)
-# can fetch the JPEGs that get referenced by snapshot_path columns.
-_snapshots_dir = Path(SNAPSHOT_DIR)
-_snapshots_dir.mkdir(exist_ok=True)
-app.mount(
-    "/pms-ai/snapshots",
-    StaticFiles(directory=_snapshots_dir, check_dir=False),
-    name="snapshots",
-)
-
 # ── Request Timing & Logging Middleware ──────────────────────────────────────
 @app.middleware("http")
 async def log_requests(request: Request, call_next):
@@ -109,6 +95,8 @@ app.include_router(parking_stats.router, prefix="/api/v1", tags=["📊 Stats —
 app.include_router(vehicles.router,      prefix="/api/v1", tags=["🔍 Vehicles — UC4"])
 
 app.include_router(parking_sessions_internal.router, prefix="/api/v1", tags=["Internal Sessions"])
+
+app.include_router(snapshots.router, tags=["📸 Snapshots"])
 
 import asyncio
 from app.database import SessionLocal

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@
 FastAPI application entry point.
 Includes security middleware, global error handlers, and all routers.
 """
+# (no-op edit: 2026-05-05 to trigger uvicorn --reload — rev 3 for close_session vehicle clear)
 
 from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
@@ -118,6 +119,10 @@ async def startup():
 
 
     logger.info(f"📡 Cameras configured: {list(settings.CAMERAS.keys())}")
+    logger.info(
+        f"🕐 Facility TZ offset: UTC+{settings.FACILITY_TIMEZONE_OFFSET_HOURS} "
+        "(env FACILITY_TIMEZONE_OFFSET_HOURS). Gateway must run with the same value."
+    )
     logger.info(f"🌐 Listening on http://{settings.BACKEND_IP}:{settings.BACKEND_PORT}")
 
 @app.on_event("shutdown")

--- a/app/models/vehicle.py
+++ b/app/models/vehicle.py
@@ -31,5 +31,12 @@ class Vehicle(Base):
     # varchar slot_id used in parking_sessions / parking_slots / slot_status.
     current_slot_id = Column(String(50), index=True)
 
+    # "Where is this car right now?" — written by VA on every track
+    # confirmation (across cameras, parked or moving) and kept in sync by
+    # bind_slot / close_session. Lets the Gateway answer presence without
+    # JOINing parking_sessions, which only has floor info while bound.
+    floor = Column(String(50))
+    floor_id = Column(Integer)
+
     def __repr__(self):
         return f"<Vehicle {self.plate_number} owner={self.owner_name} type={self.vehicle_type}>"

--- a/app/routers/entry_exit.py
+++ b/app/routers/entry_exit.py
@@ -8,7 +8,7 @@ from app.database import get_db
 from app.models.entry_exit_log import EntryExitLog
 from app.schemas.entry_exit_log import EntryExitLogResponse
 from app.schemas.responses import TodayCountResponse
-from datetime import date
+from app.config import facility_today_utc, facility_tomorrow_utc
 
 router = APIRouter()
 
@@ -24,15 +24,22 @@ def get_entry_exit_log(limit: int = 50, offset: int = 0, gate: str = None, db: S
 
 @router.get("/entry-exit/count/today", response_model=TodayCountResponse, summary="UC1 — Today's vehicle count")
 def get_today_counts(db: Session = Depends(get_db)):
-    """Returns total entries and exits for today."""
-    today = date.today()
+    """Returns total entries and exits for facility-local today.
+    The window is `[facility_today_utc(), facility_tomorrow_utc())` so it
+    matches the Gateway's dashboard tile (both read FACILITY_TIMEZONE_OFFSET_HOURS).
+    Range filter on event_time uses the existing index — faster than the
+    legacy `func.date(...) == today` and avoids server-local-clock drift."""
+    today_start = facility_today_utc()
+    today_end = facility_tomorrow_utc()
     entries = db.query(func.count(EntryExitLog.id)).filter(
         EntryExitLog.gate == "entry",
-        func.date(EntryExitLog.event_time) == today,
+        EntryExitLog.event_time >= today_start,
+        EntryExitLog.event_time < today_end,
     ).scalar()
     exits = db.query(func.count(EntryExitLog.id)).filter(
         EntryExitLog.gate == "exit",
-        func.date(EntryExitLog.event_time) == today,
+        EntryExitLog.event_time >= today_start,
+        EntryExitLog.event_time < today_end,
     ).scalar()
-    return {"date": str(today), "entries": entries, "exits": exits,
+    return {"date": today_start.date().isoformat(), "entries": entries, "exits": exits,
             "currently_parked": max(0, entries - exits)}

--- a/app/routers/parking_stats.py
+++ b/app/routers/parking_stats.py
@@ -7,7 +7,7 @@ from sqlalchemy import func
 from app.database import get_db
 from app.models.entry_exit_log import EntryExitLog
 from app.schemas.responses import ParkingTimeResponse, DailyStatsResponse
-from datetime import date
+from app.config import facility_day_range_utc, facility_today_utc
 
 router = APIRouter()
 
@@ -15,19 +15,20 @@ router = APIRouter()
 @router.get("/stats/parking-time", response_model=ParkingTimeResponse, summary="UC2 — Average parking duration")
 def get_avg_parking_time(target_date: str = None, db: Session = Depends(get_db)):
     """
-    Returns average parking duration in minutes for a given date.
-    Only includes vehicles with matched entry+exit pairs.
+    Returns average parking duration in minutes for a given facility-local date.
+    Only includes vehicles with matched entry+exit pairs. The date window is
+    facility-local (FACILITY_TIMEZONE_OFFSET_HOURS) so it matches the Gateway's
+    `/entry-exit/kpis.avg_stay_minutes` tile.
     """
-    q = db.query(func.avg(EntryExitLog.parking_duration)).filter(
+    start_utc, end_utc = facility_day_range_utc(target_date)
+    avg_seconds = db.query(func.avg(EntryExitLog.parking_duration)).filter(
         EntryExitLog.gate == "exit",
         EntryExitLog.parking_duration != None,
-    )
-    if target_date:
-        q = q.filter(func.date(EntryExitLog.event_time) == target_date)
-
-    avg_seconds = q.scalar() or 0
+        EntryExitLog.event_time >= start_utc,
+        EntryExitLog.event_time < end_utc,
+    ).scalar() or 0
     return {
-        "date": target_date or str(date.today()),
+        "date": target_date or start_utc.date().isoformat(),
         "avg_parking_minutes": round(avg_seconds / 60, 1),
         "avg_parking_seconds": round(avg_seconds, 0),
     }
@@ -35,16 +36,19 @@ def get_avg_parking_time(target_date: str = None, db: Session = Depends(get_db))
 
 @router.get("/stats/daily", response_model=DailyStatsResponse, summary="UC2 — Daily vehicle count summary")
 def get_daily_stats(target_date: str = None, db: Session = Depends(get_db)):
-    """Returns total vehicles in/out and average parking time per day."""
-    target = target_date or str(date.today())
+    """Returns total vehicles in/out and average parking time per facility-local day."""
+    start_utc, end_utc = facility_day_range_utc(target_date)
+    target = target_date or start_utc.date().isoformat()
     total = db.query(func.count(EntryExitLog.id)).filter(
         EntryExitLog.gate == "entry",
-        func.date(EntryExitLog.event_time) == target,
+        EntryExitLog.event_time >= start_utc,
+        EntryExitLog.event_time < end_utc,
     ).scalar()
     avg_dur = db.query(func.avg(EntryExitLog.parking_duration)).filter(
         EntryExitLog.gate == "exit",
         EntryExitLog.parking_duration != None,
-        func.date(EntryExitLog.event_time) == target,
+        EntryExitLog.event_time >= start_utc,
+        EntryExitLog.event_time < end_utc,
     ).scalar() or 0
     return {"date": target, "total_vehicles": total,
             "avg_parking_minutes": round(avg_dur / 60, 1)}

--- a/app/routers/snapshots.py
+++ b/app/routers/snapshots.py
@@ -1,0 +1,36 @@
+# app/routers/snapshots.py
+"""
+Serves saved camera snapshot JPEGs from the local detection_images/ folder.
+
+Replaces the previous StaticFiles mount with a regular GET endpoint so we
+can validate filenames and have a normal place to add logging or swap the
+storage backend later.
+"""
+
+import os
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse
+
+from app.services.snapshot_service import SNAPSHOT_DIR
+
+router = APIRouter()
+
+
+@router.get(
+    "/pms-ai/snapshots/{filename}",
+    summary="Serve a saved camera snapshot JPEG",
+    response_class=FileResponse,
+)
+def get_snapshot(filename: str):
+    # Reject anything that isn't a bare filename — blocks ../ traversal,
+    # absolute paths, and Windows drive specs.
+    safe_name = os.path.basename(filename)
+    if not safe_name or safe_name != filename:
+        raise HTTPException(status_code=404, detail="Snapshot not found")
+
+    filepath = os.path.join(SNAPSHOT_DIR, safe_name)
+    if not os.path.isfile(filepath):
+        raise HTTPException(status_code=404, detail="Snapshot not found")
+
+    return FileResponse(filepath, media_type="image/jpeg")

--- a/app/services/alert_service.py
+++ b/app/services/alert_service.py
@@ -8,6 +8,7 @@ from datetime import datetime, UTC
 from sqlalchemy.orm import Session
 from app.config import settings
 from app.models.alert import Alert
+from app.models.vehicle import Vehicle
 from app.utils.logger import get_logger
 from app.utils.event_bus import event_bus
 
@@ -143,6 +144,21 @@ async def create_alert(
         severity = _resolve_severity(alert_type)
         zone_meta = settings.get_zone_metadata(zone_id)
         resolved_zone_name = zone_name if zone_name is not None else zone_meta.get("zone_name") or zone_id
+
+        # Defensive slot_id fallback: when the calling site didn't pass slot_id
+        # but did pass a plate, look up vehicles.current_slot_id (kept fresh by
+        # parking_session_service.py:141 on every bind, cleared at :178-179 on
+        # unbind). This ensures alerts about a parked vehicle carry the slot
+        # they're parked in even when the call site (e.g. unknown_vehicle alert
+        # at the gate) doesn't know the slot directly.
+        if slot_id is None and plate_number:
+            try:
+                vehicle = db.query(Vehicle).filter(Vehicle.plate_number == plate_number).first()
+                if vehicle and vehicle.current_slot_id:
+                    slot_id = vehicle.current_slot_id
+            except Exception as lookup_err:
+                logger.debug(f"[ALERT] current_slot_id fallback lookup failed: {lookup_err}")
+
         location_display = _resolve_location_display(
             camera_id=camera_id,
             zone_id=zone_id,

--- a/app/services/entry_exit_service.py
+++ b/app/services/entry_exit_service.py
@@ -34,11 +34,16 @@ async def handle_anpr_event(event: ParsedCameraEvent, db: Session):
         logger.debug(f"[Phase2] ANPR event with no plate from {event.camera_id} - skipped")
         return
 
-    # Strip timezone info: camera sends tz-aware timestamps but DB stores naive UTC.
-    # Mixing the two in subtraction raises "can't subtract offset-naive and offset-aware".
+    # Convert to UTC then strip tzinfo: camera sends tz-aware timestamps (e.g.
+    # `2026-03-11T08:58+03:00`), but DB columns are naive UTC. The earlier code
+    # called `.replace(tzinfo=None)` directly, which silently dropped the offset
+    # and stored facility-local datetimes pretending to be UTC. Fix: convert
+    # first, then strip. Historical rows pre-fix are 3h ahead of true UTC
+    # (assuming Saudi +03:00 cameras) — see sql/migrate_facility_local_to_utc.sql
+    # for the one-time backfill that aligns the old data.
     event_time = event.trigger_time or datetime.now(UTC)
     if event_time.tzinfo is not None:
-        event_time = event_time.replace(tzinfo=None)
+        event_time = event_time.astimezone(UTC).replace(tzinfo=None)
 
     # Deduplication: check for recent events
     logger.debug(f"[UC1] Checking dedup for plate {plate}...")
@@ -132,7 +137,8 @@ async def handle_anpr_event(event: ParsedCameraEvent, db: Session):
             # still be tz-aware if stored before the fix, so strip it defensively.
             t2 = matching_entry.event_time
             if t2.tzinfo is not None:
-                t2 = t2.replace(tzinfo=None)
+                # Convert to UTC before stripping — see comment at line 41.
+                t2 = t2.astimezone(UTC).replace(tzinfo=None)
 
             duration_seconds = int((event_time - t2).total_seconds())
             log_entry.parking_duration = max(0, duration_seconds)

--- a/app/services/parking_session_service.py
+++ b/app/services/parking_session_service.py
@@ -16,9 +16,14 @@ logger = get_logger(__name__)
 
 
 def _naive(dt: Optional[datetime]) -> datetime:
+    """Normalize a (possibly tz-aware) datetime to naive UTC for DB columns.
+    Convert tz-aware values to UTC before stripping tzinfo — `replace(tzinfo=None)`
+    on its own silently drops the offset and would store facility-local pretending
+    to be UTC. See `entry_exit_service.py:41` for the same fix and the historical
+    data migration script `sql/migrate_facility_local_to_utc.sql`."""
     value = dt or datetime.now(UTC)
     if value.tzinfo is not None:
-        return value.replace(tzinfo=None)
+        return value.astimezone(UTC).replace(tzinfo=None)
     return value
 
 
@@ -102,6 +107,22 @@ def close_session(
     session.duration_seconds = max(0, int((exit_time - session.entry_time).total_seconds()))
     session.status = "closed"
     session.updated_at = datetime.now(UTC)
+    # If the car exited while still bound to a slot (no VA unbind before the
+    # ANPR exit event), close_session is the last writer that knows when the
+    # slot was vacated. Backfill slot_left_at so historical queries can rely
+    # on `slot_left_at IS NOT NULL` for closed sessions.
+    if session.slot_id is not None and session.slot_left_at is None:
+        session.slot_left_at = exit_time
+
+    # The car has left the garage entirely — clear all "where is it now"
+    # mirrors on the vehicle row. Without this, the vehicles row keeps
+    # pointing at the last slot/floor indefinitely.
+    vehicle = _resolve_vehicle(db, session)
+    if vehicle is not None:
+        vehicle.current_slot_id = None
+        vehicle.floor = None
+        vehicle.floor_id = None
+
     return session
 
 
@@ -131,14 +152,23 @@ def bind_slot(
     session.slot_camera_id = camera_id
     if snapshot_path:
         session.slot_snapshot_path = snapshot_path
+    # Clear slot_left_at on (re-)bind so the Gateway can rely on
+    # `slot_left_at IS NOT NULL` meaning "currently between slots".
+    # Without this, a B1->B2 move leaves the old unbind timestamp in place
+    # and downstream consumers think the car has already left B16.
+    session.slot_left_at = None
     session.updated_at = datetime.now(UTC)
 
     # Mirror the slot binding onto the vehicle row so callers that only
     # have the Vehicle (not the open session) can still answer
-    # "where is this vehicle right now?".
+    # "where is this vehicle right now?". Write floor too — VA also writes
+    # it on every track confirmation, but a fresh bind is the latest
+    # signal so it should win.
     vehicle = _resolve_vehicle(db, session)
     if vehicle is not None:
         vehicle.current_slot_id = slot_id
+        if session.floor:
+            vehicle.floor = session.floor
 
     db.flush()
     return session


### PR DESCRIPTION
## Summary

Companion to the API-Gateway lifecycle-hardening PR. Hardens the parking-session lifecycle so the Gateway's response shapes stay coherent across bind / unbind / move / exit.

- **`bind_slot`**: clears `session.slot_left_at` on (re)bind (B1→B2 was leaving the old timestamp); writes `vehicles.floor` alongside `current_slot_id`.
- **`close_session`**: backfills `slot_left_at = exit_time` when the car exits while still slot-bound; clears `vehicles.current_slot_id`, `floor`, `floor_id`.
- **`alert_service.create_alert`**: defensive `slot_id` fallback that looks up `vehicles.current_slot_id` when the upstream event omitted it.
- **`entry_exit_service`**: strip-tz bug fix — `astimezone(UTC).replace(tzinfo=None)` instead of just `replace(tzinfo=None)`. Camera +03:00 timestamps no longer land in DB as facility-local-but-tagged-UTC.
- **TZ centralisation**: new `FACILITY_TIMEZONE_OFFSET_HOURS` env var + `facility_today_utc()` helper. `entry_exit.py` and `parking_stats.py` "today" windows now derive from it. Boot logs the active offset. Must match Gateway's value or the two services' "today" diverges.
- **`models/vehicle.py`**: added `floor` / `floor_id` columns. The `vehicles` table is now the canonical "where is the car right now" source.

## Test plan

- [x] Lifecycle simulator (in API-Gateway repo) returns `Overall: PASS (5/5)` against this PMS-AI build
- [x] DB-truth check on close: `parking_sessions.status='closed'`, `exit_time IS NOT NULL`, `slot_left_at IS NOT NULL`, `duration_seconds > 0`, `vehicles.current_slot_id IS NULL`
- [x] B1→B2 move: after rebind, `parking_sessions.slot_left_at IS NULL` (was stuck before)
- [ ] Real ANPR entry+exit lands TZ-correct timestamps in DB (verify post-deploy)

## Deploy

1. Set `FACILITY_TIMEZONE_OFFSET_HOURS=3.0` in `.env` (must equal Gateway's value)
2. Restart PMS-AI after Gateway DB migrations land (the Gateway PR adds `vehicles.floor` / `floor_id` columns this code expects)