### PR TITLE
Drop vehicleMatchResult from dispatcher — match entry-camera flow to exit-camera flow

### DIFF
--- a/app/services/entry_exit_service.py
+++ b/app/services/entry_exit_service.py
@@ -1,6 +1,14 @@
 """
 Phase 2: UC1 (Entry/Exit Counting), UC2 (Parking Time), and UC4 (Vehicle ID).
-Handles AccessControllerEvent / vehicleMatchResult / ANPR from ANPR cameras.
+Handles AccessControllerEvent / ANPR from ANPR cameras.
+
+Note: `vehicleMatchResult` is intentionally NOT handled here. The dispatcher
+suppresses it (see event_dispatcher.py) because Hikvision fires it without
+an inline multipart image, which forces an ISAPI snapshot pull that some
+camera ACL configs reject. The follow-on `ANPR` event (~1-5s later) carries
+the multipart JPEG and drives row creation here. This makes entry-camera
+behaviour identical to exit-camera behaviour: both rely on the inline image,
+neither hits the ISAPI snapshot endpoint.
 """
 
 from datetime import datetime, UTC, timedelta

--- a/app/services/event_dispatcher.py
+++ b/app/services/event_dispatcher.py
@@ -27,9 +27,19 @@ async def dispatch_event(event: ParsedCameraEvent, db: Session) -> dict:
     # 1. Use multipart image if the camera attached one to the event (already saved locally)
     # 2. If no image → try fetching a fresh snapshot from the camera (saves locally)
     # 3. If camera is unreachable → leave snapshot_path as None
+    #
+    # `vehicleMatchResult` is intentionally excluded: it arrives WITHOUT an
+    # inline multipart image, which forces the ISAPI snapshot fetch path —
+    # the path that 401s on entry cameras whose ISAPI ACL differs from the
+    # exit camera's. Hikvision always fires a follow-on `ANPR` event ~1-5s
+    # later that DOES carry the multipart JPEG, and that's what we use.
+    # Treating both event types as canonical led to duplicate snapshot
+    # attempts and the row being created from the imageless event first
+    # (then dedup-suppressing the imageful event). See engine_dispatcher
+    # commit history for the customer-prod RDJ-9640 case.
     SNAPSHOT_EVENT_TYPES = (
         "fielddetection", "linedetection", "regionEntrance",
-        "AccessControllerEvent", "vehicleMatchResult", "ANPR",
+        "AccessControllerEvent", "ANPR",
     )
     if event.event_type in SNAPSHOT_EVENT_TYPES:
         # event_parser.parse_camera_event already sets snapshot_path (URL) and
@@ -49,6 +59,17 @@ async def dispatch_event(event: ParsedCameraEvent, db: Session) -> dict:
         # VMD = Video Motion Detection: basic motion, not a Smart Event.
         # Ignore it completely per user request — fires constantly and has no zone info.
         if event.event_type == "VMD":
+            return
+
+        # vehicleMatchResult: the imageless precursor to ANPR. We deliberately
+        # don't process it here — see SNAPSHOT_EVENT_TYPES comment above. Just
+        # log at DEBUG so we can confirm the camera fired it but we ignored it.
+        if event.event_type == "vehicleMatchResult":
+            logger.debug(
+                "[dispatch] Skipping vehicleMatchResult from %s plate=%s — "
+                "follow-on ANPR event will carry the multipart image",
+                event.camera_id, event.plate_number,
+            )
             return
 
         is_gate = settings.CAMERAS.get(event.camera_id, {}).get("gate") in ("entry", "exit")
@@ -81,7 +102,9 @@ async def dispatch_event(event: ParsedCameraEvent, db: Session) -> dict:
 
         # ── CAMERA FEED ──────────────────────────────────────────────────────
         # Log all entry/exit related smart events to the CameraFeed table.
-        FEED_EVENT_TYPES = ("ANPR", "vehicleMatchResult", "AccessControllerEvent", "linedetection")
+        # `vehicleMatchResult` excluded — ANPR follows ~1-5s later with the
+        # same plate + an inline image, so it's the canonical row to log.
+        FEED_EVENT_TYPES = ("ANPR", "AccessControllerEvent", "linedetection")
         if event.event_type in FEED_EVENT_TYPES:
             add_event_to_feed(db, event)
 
@@ -102,8 +125,12 @@ async def dispatch_event(event: ParsedCameraEvent, db: Session) -> dict:
              logger.debug(f"[UC3] Gate camera {event.camera_id} sent non-occupancy event: {event.event_type}")
 
         # ── PHASE 2 ───────────────────────────────────────────────────────────
-        # UC1 + UC2 + UC4: ANPR gate events (JSON=AccessControllerEvent, XML=ANPR/vehicleMatchResult)
-        if event.event_type in ("ANPR", "vehicleMatchResult", "AccessControllerEvent") and event.plate_number:
+        # UC1 + UC2 + UC4: ANPR gate events (JSON=AccessControllerEvent, XML=ANPR).
+        # `vehicleMatchResult` is suppressed at the top of this function — only
+        # ANPR (with multipart JPEG) drives entry_exit_log creation. This makes
+        # the entry-camera flow identical to the exit-camera flow: both rely on
+        # the inline multipart image, neither needs the ISAPI snapshot fetch.
+        if event.event_type in ("ANPR", "AccessControllerEvent") and event.plate_number:
             await handle_anpr_event(event, db)
 
         # ── MAINTENANCE ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The customer's exit camera "always works" because it sends a single `ANPR` event per car with the JPEG embedded in multipart — PMS-AI never hits the ISAPI snapshot endpoint. The entry camera sends two events:

1. `vehicleMatchResult` — metadata only, no inline image
2. `ANPR` ~1-5s later — same plate, multipart JPEG inline

The old dispatcher tried to drive `entry_exit_log` from `vehicleMatchResult`, which forced an ISAPI snapshot pull. That pull 401s on the customer's entry camera (per-camera ACL difference — not a credential issue, since the same auth scheme works on the exit camera). The row was then created with `snapshot_path=NULL`. The follow-on `ANPR` event 1-5s later — which DID carry the multipart image — was suppressed by the 30s dedup window, so its image was dropped on the floor.

## What this PR does

Make the entry-camera flow identical to the exit-camera flow: ignore `vehicleMatchResult` entirely. Only `ANPR` and `AccessControllerEvent` drive `entry_exit_log` creation. Both rely on the inline multipart JPEG. Neither triggers the ISAPI snapshot fetch.

Three places in `event_dispatcher.py`:
- **`SNAPSHOT_EVENT_TYPES`** — drop `vehicleMatchResult`. Imageless events no longer trigger ISAPI snapshot fetch.
- **`FEED_EVENT_TYPES`** — drop `vehicleMatchResult`. Avoids double-logging the same physical event to `camera_feeds` (ANPR covers it).
- **`handle_anpr_event` dispatch tuple** — drop `vehicleMatchResult`. Only ANPR / AccessControllerEvent create entry/exit rows.

Plus an explicit early-return at the top of the dispatcher with a DEBUG log line so ops can see the suppression in audit:

```
[dispatch] Skipping vehicleMatchResult from CAM-ENTRY plate=RDJ-9640 —
follow-on ANPR event will carry the multipart image
```

## Files changed

- `app/services/event_dispatcher.py` — three event-type tuples + new early-return for vehicleMatchResult
- `app/services/entry_exit_service.py` — docstring update reflecting that vehicleMatchResult is no longer handled here

## Test plan

- [x] `py_compile` clean
- [ ] Customer-prod replay of plate RDJ-9640: expect ONE `entry_exit_log` row from the ANPR event with `snapshot_path` populated from the multipart JPEG
- [ ] Customer-prod log: expect zero `GET .../picture` calls to `10.1.13.100` for entry events
- [ ] Customer-prod log: expect a single `[dispatch] Skipping vehicleMatchResult from CAM-ENTRY` line per car (DEBUG level — only visible if LOG_LEVEL=DEBUG)
- [ ] Lifecycle simulator (in API-Gateway repo) still PASS 5/5 — no regression on dev where `vehicleMatchResult` isn't fired

## Risk

If a Hikvision camera somewhere fires `vehicleMatchResult` WITHOUT a follow-on `ANPR`, its events would now be silently dropped. We have no evidence of such a camera in the customer's deployment — every observed Hikvision ANPR camera fires both. The DEBUG log line lets ops detect a regression. If one is found, the workaround is to keep `vehicleMatchResult` in the dispatch tuple but skip the snapshot fetch for it.

## Deploy

1. Pull this branch on the customer's PMS-AI host
2. Restart PMS-AI
3. No camera-side changes required
4. The pending `Live View` / `Image Capture` ACL fix on `10.1.13.100` is now optional — ISAPI snapshot fetch is no longer in the entry-event path