### PR TITLE
fix: store DB datetimes as naive facility-local instead of naive UTC

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -376,42 +376,63 @@ settings = Settings()
 def facility_tz():
     """The local timezone for "today"-style date math. Configured via
     FACILITY_TIMEZONE_OFFSET_HOURS env var (default 3.0 = UTC+3, Saudi Arabia).
-    DB columns are stored as UTC-naive; this offset only affects boundary
-    calculations like "since local midnight today"."""
+
+    NEW (2026-05-07): the DB convention shifted from UTC-naive to
+    facility-local-naive — every writer now stores the wall-clock time
+    operators see, so the customer's dashboard shows the right values
+    without any UTC->local math on the frontend. This `facility_tz()`
+    helper is still useful for parsing tz-aware camera timestamps before
+    stripping the tz."""
     from datetime import timezone, timedelta
     return timezone(timedelta(hours=settings.FACILITY_TIMEZONE_OFFSET_HOURS))
 
 
+def facility_now_naive():
+    """Current facility-local datetime, NAIVE (no tzinfo). Use this for
+    every DB write where you used to call `datetime.now(UTC)` or
+    `datetime.utcnow()`. The DB convention is "naive datetime is the
+    facility wall clock"; calling utcnow() in a UTC-tzed container
+    silently subtracts the facility offset and lands rows 3h behind.
+
+    Equivalent (but explicit) to `datetime.now(facility_tz()).replace(tzinfo=None)`,
+    works regardless of the host OS / container TZ."""
+    from datetime import datetime
+    return datetime.now(facility_tz()).replace(tzinfo=None)
+
+
 def facility_today_utc():
-    """Naive UTC datetime of facility-local midnight today. Use this when
-    filtering DB columns stored as UTC-naive datetimes against "since local
-    midnight today" — pair with `facility_tomorrow_utc()` for an exclusive
-    upper bound."""
-    from datetime import datetime, timezone
+    """[name kept for back-compat; semantics shifted 2026-05-07]
+    Naive facility-local datetime of midnight today. Use this when
+    filtering DB columns stored as facility-local-naive datetimes
+    against "since local midnight today" — pair with
+    `facility_tomorrow_utc()` for an exclusive upper bound. Despite the
+    name, this no longer involves UTC."""
+    from datetime import datetime
     now_local = datetime.now(facility_tz())
     midnight_local = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
-    return midnight_local.astimezone(timezone.utc).replace(tzinfo=None)
+    return midnight_local.replace(tzinfo=None)
 
 
 def facility_tomorrow_utc():
-    """Naive UTC datetime of facility-local midnight at the END of today
-    (start of tomorrow). Pairs with facility_today_utc() for range filters."""
+    """Naive facility-local datetime of midnight at the END of today
+    (start of tomorrow). Pairs with `facility_today_utc()` for range
+    filters."""
     from datetime import timedelta
     return facility_today_utc() + timedelta(days=1)
 
 
 def facility_day_range_utc(target_date_str: str | None = None):
-    """Return (start_utc, end_utc) range for a facility-local day. If
-    target_date_str is None, uses today. Pass a string like "2026-04-13" to
-    get any date's window. Both bounds are naive UTC datetimes suitable for
-    filtering DB columns stored as UTC-naive."""
-    from datetime import datetime, timezone, date as date_cls, timedelta
+    """Return (start, end) naive facility-local range for a given day. If
+    target_date_str is None, uses today. Pass a string like "2026-04-13"
+    to get any date's window. Both bounds are naive facility-local
+    datetimes suitable for filtering DB columns stored facility-local-naive."""
+    from datetime import datetime, date as date_cls, timedelta
     if target_date_str is None:
         start = facility_today_utc()
     else:
         d = date_cls.fromisoformat(target_date_str)
-        start_local = datetime(d.year, d.month, d.day, tzinfo=facility_tz())
-        start = start_local.astimezone(timezone.utc).replace(tzinfo=None)
+        # Naive facility-local datetime at midnight of the target date.
+        start = datetime(d.year, d.month, d.day)
     end = start + timedelta(days=1)
     return start, end
 

--- a/app/routers/health.py
+++ b/app/routers/health.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from sqlalchemy import text
 from app.database import get_db
-from app.config import settings
+from app.config import settings, facility_now_naive
 from app.schemas.responses import HealthResponse
 from app.utils.logger import get_logger
 from datetime import datetime, UTC
@@ -30,7 +30,7 @@ def health_check(db: Session = Depends(get_db)):
 
     result = {
         "status": "ok",
-        "timestamp": datetime.now(UTC).isoformat(),
+        "timestamp": facility_now_naive().isoformat(),
         "backend": "ok",
         "database": "unknown",
         "cameras": list(settings.CAMERAS.keys()),

--- a/app/routers/occupancy.py
+++ b/app/routers/occupancy.py
@@ -4,7 +4,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from datetime import datetime, UTC
-from app.config import settings
+from app.config import settings, facility_now_naive
 from app.database import get_db
 from app.models.zone_occupancy import ZoneOccupancy
 from app.schemas.zone_occupancy import ZoneOccupancyOut, ZoneCapacityUpdate
@@ -47,7 +47,7 @@ def set_zone_capacity(zone_id: str, body: ZoneCapacityUpdate, db: Session = Depe
                              zone_name=zone_meta.get("zone_name"),
                              floor=zone_meta.get("floor"),
                              current_count=0, max_capacity=body.max_capacity,
-                             last_updated=datetime.now(UTC))
+                             last_updated=facility_now_naive())
         db.add(zone)
     else:
         zone.max_capacity = body.max_capacity
@@ -66,7 +66,7 @@ def reset_zone_count(zone_id: str, db: Session = Depends(get_db)):
     if not zone:
         raise HTTPException(status_code=404, detail=f"Zone '{zone_id}' not found")
     zone.current_count = 0
-    zone.last_updated = datetime.now(UTC)
+    zone.last_updated = facility_now_naive()
     db.commit()
     return {"zone_id": zone_id, "current_count": 0, "status": "reset"}
 

--- a/app/services/alert_service.py
+++ b/app/services/alert_service.py
@@ -6,7 +6,7 @@ Used by occupancy_service, violation_service, intrusion_service, and entry_exit_
 
 from datetime import datetime, UTC
 from sqlalchemy.orm import Session
-from app.config import settings
+from app.config import settings, facility_now_naive
 from app.models.alert import Alert
 from app.models.vehicle import Vehicle
 from app.utils.logger import get_logger
@@ -70,7 +70,7 @@ async def broadcast_event(
         "description": description,
         "plate_number": plate_number,
         "snapshot_path": snapshot_path,
-        "triggered_at": (triggered_at or datetime.now(UTC)).isoformat(),
+        "triggered_at": (triggered_at or facility_now_naive()).isoformat(),
         # Breadcrumbs for internal debugging
         "internal_meta": {
             "zone_id": zone_id,
@@ -180,7 +180,7 @@ async def create_alert(
             severity=severity,
             location_display=location_display,
             is_resolved=False,
-            triggered_at=datetime.now(UTC),
+            triggered_at=facility_now_naive(),
         )
 
         logger.warning(
@@ -220,7 +220,7 @@ async def create_alert(
             slot_number=slot_number,
             plate_number=plate_number,
             snapshot_path=snapshot_path,
-            triggered_at=new_alert.triggered_at if new_alert else datetime.now(UTC),
+            triggered_at=new_alert.triggered_at if new_alert else facility_now_naive(),
         )
 
     except Exception as e:

--- a/app/services/camera_feed_service.py
+++ b/app/services/camera_feed_service.py
@@ -1,7 +1,7 @@
 from datetime import datetime, UTC
 from sqlalchemy.orm import Session
 from app.models.camera_feed import CameraFeed
-from app.config import settings
+from app.config import settings, facility_now_naive
 from app.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -61,7 +61,7 @@ def add_event_to_feed(db: Session, event):
             detection_source=detection_source,
             plate_number=getattr(event, "plate_number", None),
             snapshot_path=event.snapshot_path,
-            timestamp=event.trigger_time or datetime.now(UTC)
+            timestamp=event.trigger_time or facility_now_naive()
         )
 
         db.add(feed_entry)

--- a/app/services/entry_exit_service.py
+++ b/app/services/entry_exit_service.py
@@ -11,14 +11,14 @@ behaviour identical to exit-camera behaviour: both rely on the inline image,
 neither hits the ISAPI snapshot endpoint.
 """
 
-from datetime import datetime, UTC, timedelta
+from datetime import timedelta
 from sqlalchemy.orm import Session
 from app.models.entry_exit_log import EntryExitLog
 from app.services import parking_session_service
 from app.services import vehicle_service
 from app.services.event_parser import ParsedCameraEvent
 from app.services.alert_service import create_alert
-from app.config import settings
+from app.config import settings, facility_now_naive, facility_tz
 from app.utils.logger import get_logger
 from app.utils import core_backend_client
 
@@ -42,16 +42,16 @@ async def handle_anpr_event(event: ParsedCameraEvent, db: Session):
         logger.debug(f"[Phase2] ANPR event with no plate from {event.camera_id} - skipped")
         return
 
-    # Convert to UTC then strip tzinfo: camera sends tz-aware timestamps (e.g.
-    # `2026-03-11T08:58+03:00`), but DB columns are naive UTC. The earlier code
-    # called `.replace(tzinfo=None)` directly, which silently dropped the offset
-    # and stored facility-local datetimes pretending to be UTC. Fix: convert
-    # first, then strip. Historical rows pre-fix are 3h ahead of true UTC
-    # (assuming Saudi +03:00 cameras) — see sql/migrate_facility_local_to_utc.sql
-    # for the one-time backfill that aligns the old data.
-    event_time = event.trigger_time or datetime.now(UTC)
-    # if event_time.tzinfo is not None:
-    #     event_time = event_time.astimezone(UTC).replace(tzinfo=None)
+    # Camera sends tz-aware timestamps like `2026-05-07T12:14:51+03:00`. The
+    # DB convention (since 2026-05-07) is NAIVE FACILITY-LOCAL — the wall
+    # clock the operator sees, NOT UTC. Convert to facility tz first, then
+    # strip tzinfo, so 12:14:51+03:00 stays 12:14:51 in the column. Earlier
+    # code converted to UTC and stored 09:14:51, which made the dashboard
+    # display 3h behind. astimezone(facility_tz) is idempotent if the value
+    # is already in facility tz.
+    event_time = event.trigger_time or facility_now_naive()
+    if event_time.tzinfo is not None:
+        event_time = event_time.astimezone(facility_tz()).replace(tzinfo=None)
 
     # Deduplication: check for recent events
     logger.debug(f"[UC1] Checking dedup for plate {plate}...")
@@ -129,7 +129,7 @@ async def handle_anpr_event(event: ParsedCameraEvent, db: Session):
         camera_id=event.camera_id,
         event_time=event_time,
         snapshot_path=event.snapshot_path,
-        created_at=datetime.now(UTC),
+        created_at=facility_now_naive(),
     )
 
     if gate == "entry":
@@ -156,12 +156,13 @@ async def handle_anpr_event(event: ParsedCameraEvent, db: Session):
         )
 
         if matching_entry:
-            # event_time is already naive (normalized above); matching_entry may
-            # still be tz-aware if stored before the fix, so strip it defensively.
+            # event_time is already naive facility-local (normalized above);
+            # matching_entry may still be tz-aware if stored before the fix,
+            # so strip it defensively. Convert to facility tz first to keep
+            # the wall-clock value, matching the new DB convention.
             t2 = matching_entry.event_time
             if t2.tzinfo is not None:
-                # Convert to UTC before stripping — see comment at line 41.
-                t2 = t2.astimezone(UTC).replace(tzinfo=None)
+                t2 = t2.astimezone(facility_tz()).replace(tzinfo=None)
 
             duration_seconds = int((event_time - t2).total_seconds())
             log_entry.parking_duration = max(0, duration_seconds)

--- a/app/services/event_parser.py
+++ b/app/services/event_parser.py
@@ -12,7 +12,7 @@ import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from datetime import datetime, UTC
 from typing import Optional, List, Dict
-from app.config import settings
+from app.config import settings, facility_now_naive
 from app.services.snapshot_service import to_public_snapshot_url
 from app.utils.logger import get_logger
 
@@ -111,7 +111,7 @@ def _extract_from_multipart(raw_body: bytes, content_type: str, camera_id: str, 
     for p in parts:
         ct = p["content_type"]
         if "image/" in ct.lower():
-            timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S_%f")
+            timestamp = facility_now_naive().strftime("%Y%m%d_%H%M%S_%f")
             filename = f"part_{event_type}_{camera_id}_{timestamp}.jpg"
             filepath = os.path.join(SNAPSHOT_DIR, filename)
             try:
@@ -160,7 +160,7 @@ def parse_camera_event(raw_body: bytes, camera_ip: str, content_type: str = "") 
         # Rename the placeholder image file to use actual event type and resolved camera_id
         if "multipart" in snapshot_path:
             # We reconstruct the filename because temp_camera_id might have been UNKNOWN if IP was masked
-            timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S_%f")
+            timestamp = facility_now_naive().strftime("%Y%m%d_%H%M%S_%f")
             correct_filename = os.path.join(SNAPSHOT_DIR, f"snapshot_{event.event_type}_{event.camera_id}_{timestamp}.jpg")
             try:
                 os.rename(snapshot_path, correct_filename)
@@ -203,7 +203,7 @@ def _parse_xml_event(raw_body: bytes, camera_ip: str) -> ParsedCameraEvent:
         return el.text.strip() if el is not None and el.text else None
 
     # Resolve Trigger Time
-    trigger_time = datetime.now(UTC)
+    trigger_time = facility_now_naive()
     t_str = find_text("triggerTime") or find_text("dateTime")
     if t_str:
         try:
@@ -385,7 +385,7 @@ def _parse_json_event(raw_body: bytes, camera_ip: str) -> ParsedCameraEvent:
         raise
 
     # Resolve Trigger Time
-    trigger_time = datetime.now(UTC)
+    trigger_time = facility_now_naive()
     dt_str = data.get("dateTime", "")
     if dt_str:
         try:

--- a/app/services/occupancy_service.py
+++ b/app/services/occupancy_service.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 from app.models.zone_occupancy import ZoneOccupancy
 from app.services.event_parser import ParsedCameraEvent
 from app.services.alert_service import create_alert
-from app.config import settings
+from app.config import settings, facility_now_naive
 from app.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -57,7 +57,7 @@ async def _update_zone_count(zone_id: str, camera_id: str, delta: int, db: Sessi
             camera_id=camera_id,
             current_count=0,
             max_capacity=zone_meta.get("max_capacity") or settings.DEFAULT_ZONE_CAPACITY,
-            last_updated=datetime.now(UTC),
+            last_updated=facility_now_naive(),
         )
         db.add(zone)
         db.flush()
@@ -80,7 +80,7 @@ async def _update_zone_count(zone_id: str, camera_id: str, delta: int, db: Sessi
     # FIX #3: removed non-atomic ORM clamp (if zone.current_count < 0: zone.current_count = 0)
     # The atomic func.max() in push_db_update now handles this.
 
-    zone.last_updated = datetime.now(UTC)
+    zone.last_updated = facility_now_naive()
     occupancy_ratio = (zone.current_count / zone.max_capacity) if zone.max_capacity > 0 else 0
     pct = int(occupancy_ratio * 100)
 
@@ -104,7 +104,7 @@ def _cache_cleanup():
     FIX #4 (cache memory leak): evict entries older than CACHE_TTL_SECONDS.
     Called on every new cache insert to bound memory growth over long uptimes.
     """
-    now = datetime.now(UTC).timestamp()
+    now = facility_now_naive().timestamp()
     expired = [k for k, v in _processed_events_cache.items() if now - v >= CACHE_TTL_SECONDS]
     for k in expired:
         del _processed_events_cache[k]
@@ -117,7 +117,7 @@ def record_event_in_cache(cache_key: tuple):
     If the transaction rolls back, the cache stays clean and camera retries are accepted.
     """
     _cache_cleanup()  # FIX #4: prune stale entries on every insert
-    _processed_events_cache[cache_key] = datetime.now(UTC).timestamp()
+    _processed_events_cache[cache_key] = facility_now_naive().timestamp()
 
 
 async def handle_occupancy_event(event: ParsedCameraEvent, db: Session):
@@ -143,7 +143,7 @@ async def handle_occupancy_event(event: ParsedCameraEvent, db: Session):
     # 3. Deduplication: Ignore identical events within CACHE_TTL_SECONDS
     # FIX #5: uses EVENT_STREAM_SUPPRESS_SECONDS (30s) instead of hardcoded 1s
     cache_key = (event.camera_id, event.event_type, event.region_id or event.crossing_direction)
-    now = datetime.now(UTC).timestamp()
+    now = facility_now_naive().timestamp()
     if cache_key in _processed_events_cache:
         last_time = _processed_events_cache[cache_key]
         if now - last_time < CACHE_TTL_SECONDS:

--- a/app/services/parking_session_service.py
+++ b/app/services/parking_session_service.py
@@ -2,12 +2,12 @@
 Service helpers for the parking_sessions read model.
 """
 
-from datetime import datetime, UTC
+from datetime import datetime
 from typing import Optional
 
 from sqlalchemy.orm import Session
 
-from app.config import settings
+from app.config import settings, facility_now_naive, facility_tz
 from app.models.parking_session import ParkingSession
 from app.models.vehicle import Vehicle
 from app.utils.logger import get_logger
@@ -16,14 +16,15 @@ logger = get_logger(__name__)
 
 
 def _naive(dt: Optional[datetime]) -> datetime:
-    """Normalize a (possibly tz-aware) datetime to naive UTC for DB columns.
-    Convert tz-aware values to UTC before stripping tzinfo — `replace(tzinfo=None)`
-    on its own silently drops the offset and would store facility-local pretending
-    to be UTC. See `entry_exit_service.py:41` for the same fix and the historical
-    data migration script `sql/migrate_facility_local_to_utc.sql`."""
-    value = dt or datetime.now(UTC)
+    """Normalize a (possibly tz-aware) datetime to NAIVE FACILITY-LOCAL for DB
+    columns. Convert tz-aware values to facility tz before stripping tzinfo
+    so the stored value matches the operator's wall clock. The DB convention
+    shifted 2026-05-07 from naive UTC to naive facility-local — every writer
+    must agree, otherwise sessions and entry-exit rows drift apart by the
+    facility offset."""
+    value = dt or facility_now_naive()
     if value.tzinfo is not None:
-        return value.astimezone(UTC).replace(tzinfo=None)
+        return value.astimezone(facility_tz()).replace(tzinfo=None)
     return value
 
 
@@ -65,12 +66,12 @@ def open_session(
 ) -> ParkingSession:
     existing = get_latest_open_session(db, plate_number)
     if existing:
-        existing.updated_at = datetime.now(UTC)
+        existing.updated_at = facility_now_naive()
         if snapshot_path and not existing.entry_snapshot_path:
             existing.entry_snapshot_path = snapshot_path
         return existing
 
-    now = datetime.now(UTC)
+    now = facility_now_naive()
     session = ParkingSession(
         plate_number=plate_number,
         vehicle_id=vehicle.id if vehicle else None,
@@ -106,7 +107,7 @@ def close_session(
     session.exit_snapshot_path = snapshot_path
     session.duration_seconds = max(0, int((exit_time - session.entry_time).total_seconds()))
     session.status = "closed"
-    session.updated_at = datetime.now(UTC)
+    session.updated_at = facility_now_naive()
     # If the car exited while still bound to a slot (no VA unbind before the
     # ANPR exit event), close_session is the last writer that knows when the
     # slot was vacated. Backfill slot_left_at so historical queries can rely
@@ -148,7 +149,7 @@ def bind_slot(
     session.zone_id = zone_id
     session.zone_name = zone_name or zone_meta.get("zone_name") or zone_id
     session.floor = floor or zone_meta.get("floor")
-    session.parked_at = _naive(parked_at) if parked_at else datetime.now(UTC)
+    session.parked_at = _naive(parked_at) if parked_at else facility_now_naive()
     session.slot_camera_id = camera_id
     if snapshot_path:
         session.slot_snapshot_path = snapshot_path
@@ -157,7 +158,7 @@ def bind_slot(
     # Without this, a B1->B2 move leaves the old unbind timestamp in place
     # and downstream consumers think the car has already left B16.
     session.slot_left_at = None
-    session.updated_at = datetime.now(UTC)
+    session.updated_at = facility_now_naive()
 
     # Mirror the slot binding onto the vehicle row so callers that only
     # have the Vehicle (not the open session) can still answer
@@ -195,11 +196,11 @@ def unbind_slot(
             f"Open parking session for plate {plate_number} is bound to slot id {session.slot_id}, not {slot_id}"
         )
 
-    session.slot_left_at = _naive(left_at) if left_at else datetime.now(UTC)
+    session.slot_left_at = _naive(left_at) if left_at else facility_now_naive()
     session.slot_camera_id = camera_id
     if snapshot_path:
         session.slot_snapshot_path = snapshot_path
-    session.updated_at = datetime.now(UTC)
+    session.updated_at = facility_now_naive()
 
     # Clear the slot binding on the vehicle, but only if it still points
     # at the slot we're unbinding — otherwise we'd clobber a concurrent

--- a/app/services/vehicle_service.py
+++ b/app/services/vehicle_service.py
@@ -9,6 +9,7 @@ from datetime import datetime, UTC
 from sqlalchemy.orm import Session
 from app.models.vehicle import Vehicle
 from app.utils.logger import get_logger
+from app.config import facility_now_naive
 
 # Note: Assuming vehicle_repo is implemented in app.repositories
 try:
@@ -79,7 +80,7 @@ def register_vehicle(db: Session, plate_number: str, owner_name: str,
         email=email,
         notes=notes,
         is_registered=True,
-        registered_at=datetime.now(UTC),
+        registered_at=facility_now_naive(),
     )
 
     if vehicle_repo:
@@ -173,7 +174,7 @@ def update_vehicle(
         vehicle.notes = notes
     if is_registered is not None:
         vehicle.is_registered = is_registered
-        vehicle.registered_at = datetime.now(UTC) if is_registered else None
+        vehicle.registered_at = facility_now_naive() if is_registered else None
 
     logger.info("Updated vehicle profile: %s", plate)
     return vehicle


### PR DESCRIPTION
## Summary

Customer prod displayed every event timestamp 3 hours behind the operator's wall clock. The root cause is that `datetime.now(UTC)` and `datetime.utcnow()` always return UTC, regardless of host TZ. On a K8s pod with `TZ=UTC` (default for most container images), even `datetime.now()` returns UTC. The DB columns stored those UTC values naive, the API emitted naive ISO strings without offset, and the frontend rendered the bare string — losing the 3-hour shift the camera originally indicated.

**Convention shift:** writers now store the wall-clock time the operator sees. Readers emit it unchanged. No UTC->local math anywhere in the chain.

## Changes

| File | What |
|---|---|
| `app/config.py` | New `facility_now_naive()` helper. `facility_today_utc()` updated to return naive facility-local (semantics shifted; name kept for back-compat with router callers). |
| `app/services/parking_session_service.py` | `_naive()` helper now converts to facility tz before stripping tzinfo. 7 `datetime.now(UTC)` -> `facility_now_naive()`. |
| `app/services/entry_exit_service.py` | `event_time` conversion uses `facility_tz()` instead of UTC. `t2` dedup math too. `created_at` -> `facility_now_naive()`. |
| `app/services/alert_service.py` | 3 `datetime.now(UTC)` -> `facility_now_naive()`. |
| `app/services/camera_feed_service.py` | `timestamp` -> `facility_now_naive()`. |
| `app/services/event_parser.py` | Trigger-time fallback + filename ts -> `facility_now_naive()` (4 sites). |
| `app/services/occupancy_service.py` | Zone `last_updated` + cache stamps -> `facility_now_naive()` (5 sites). |
| `app/services/vehicle_service.py` | `registered_at` -> `facility_now_naive()` (2 sites). |
| `app/routers/health.py` | Response timestamp -> `facility_now_naive()`. |
| `app/routers/occupancy.py` | Legacy zone update -> `facility_now_naive()` (2 sites). |

## Companion PRs (deploy in lockstep)

- `API-Gateway` PR #5 — `facility_now_naive()` helper + `facility_today_utc()` semantic shift; simulator `SYSUTCDATETIME()` -> parameterized facility-local naive
- `Damanat-PMS-VideoAnalytics` PR — every `datetime.utcnow` / `datetime.now()` writer routed through new `src/utils/datetime_helper.facility_now_naive()`

## Test plan

- [x] `py_compile` clean on all modified files
- [ ] Real camera entry event lands `entry_exit_log.event_time` matching the wall clock (e.g. 12:14, not 09:14)
- [ ] Real exit event matches `entry_exit_log.event_time` to the wall clock
- [ ] `/api/v1/entry-exit/count/today` returns the correct day-window count after midnight
- [ ] `parking_sessions.entry_time/exit_time/parked_at/slot_left_at/updated_at` all show wall-clock values
- [ ] `alerts.triggered_at` shows wall-clock value
- [ ] Lifecycle simulator (in API-Gateway repo) passes 5/5

## Risk

Forward-only convention shift. Existing rows pre-deploy stay naive UTC and display 3h behind until either:
1. Customer resets the DB via the `/admin/reset` endpoint (already shipped), or
2. A one-shot SQL UPDATE shifts historical rows by +3h:
   ```sql
   UPDATE alerts SET triggered_at = DATEADD(hour, 3, triggered_at), resolved_at = DATEADD(hour, 3, resolved_at) WHERE triggered_at < '<deploy_timestamp>';
   UPDATE parking_sessions SET entry_time = DATEADD(hour, 3, entry_time), exit_time = DATEADD(hour, 3, exit_time), parked_at = DATEADD(hour, 3, parked_at), slot_left_at = DATEADD(hour, 3, slot_left_at), updated_at = DATEADD(hour, 3, updated_at), created_at = DATEADD(hour, 3, created_at) WHERE entry_time < '<deploy_timestamp>';
   UPDATE entry_exit_log SET event_time = DATEADD(hour, 3, event_time), created_at = DATEADD(hour, 3, created_at) WHERE event_time < '<deploy_timestamp>';
   ```

Future rows from any of the three services land facility-local immediately after deploy.

## Deploy

1. Merge this PR + the two companion PRs together
2. Restart Gateway, PMS-AI, VA in any order
3. Optional: run the +3h SQL UPDATE above if not resetting the DB