### PR TITLE
feat: two-phase entry confirmation via CAM-03 + fix all test failures

### DIFF
--- a/app/services/entry_exit_service.py
+++ b/app/services/entry_exit_service.py
@@ -24,6 +24,61 @@ from app.utils import core_backend_client
 
 logger = get_logger(__name__)
 
+# Pending entry cache: ANPR fired but car hasn't crossed CAM-03 yet.
+# Key: plate_number. Value: dict with all data needed to write entry_exit_log.
+# Entries expire after PENDING_ENTRY_TTL_SECONDS if CAM-03 never fires (false trigger).
+_pending_entries: dict = {}
+PENDING_ENTRY_TTL_SECONDS = 120
+
+
+def _cleanup_pending():
+    now = facility_now_naive()
+    expired = [
+        p for p, d in _pending_entries.items()
+        if (now - d["event_time"]).total_seconds() > PENDING_ENTRY_TTL_SECONDS
+    ]
+    for p in expired:
+        logger.debug(f"[UC1] Pending entry expired (no CAM-03 confirmation): plate={p}")
+        del _pending_entries[p]
+
+
+async def confirm_pending_entry(db: Session):
+    """
+    Called by occupancy_service when CAM-03 fires in the entry direction.
+    Consumes the oldest pending ANPR event and writes it to entry_exit_log.
+    FIFO: the car that triggered ANPR first is the one physically at the ramp now.
+    """
+    _cleanup_pending()
+    if not _pending_entries:
+        logger.info("[UC1] CAM-03 entry confirmed — no pending ANPR, unidentified vehicle skipped")
+        return
+
+    oldest_plate = min(_pending_entries, key=lambda p: _pending_entries[p]["event_time"])
+    pending = _pending_entries.pop(oldest_plate)
+
+    log_entry = EntryExitLog(
+        plate_number=pending["plate"],
+        vehicle_id=pending["vehicle"].id if pending["vehicle"] else None,
+        vehicle_type=pending["vehicle_type"],
+        gate="entry",
+        camera_id=pending["camera_id"],
+        event_time=pending["event_time"],
+        snapshot_path=pending["snapshot_path"],
+        created_at=facility_now_naive(),
+    )
+    db.add(log_entry)
+
+    parking_session_service.open_session(
+        db,
+        plate_number=pending["plate"],
+        event_time=pending["event_time"],
+        camera_id=pending["camera_id"],
+        snapshot_path=pending["snapshot_path"],
+        vehicle=pending["vehicle"],
+    )
+    logger.info(f"[UC1] Entry CONFIRMED by CAM-03 for plate={oldest_plate}")
+
+
 async def handle_anpr_event(event: ParsedCameraEvent, db: Session):
     """
     Process ANPR events to log vehicle movement, identify owners,
@@ -121,6 +176,48 @@ async def handle_anpr_event(event: ParsedCameraEvent, db: Session):
 
     logger.info(f"[UC1] Gate={gate} | Plate={plate} | Type={vehicle_type}")
 
+    # ── ENTRY: defer DB write until CAM-03 confirms car actually entered ──
+    if gate == "entry":
+        _cleanup_pending()
+        _pending_entries[plate] = {
+            "plate": plate,
+            "camera_id": event.camera_id,
+            "event_time": event_time,
+            "snapshot_path": event.snapshot_path,
+            "vehicle": vehicle,
+            "vehicle_type": vehicle_type,
+        }
+        logger.info(f"[UC1] ANPR entry pending CAM-03 confirmation: plate={plate}")
+
+        # UC4: alert/notification fires immediately even though DB write is deferred
+        if vehicle and vehicle.is_registered:
+            from app.services.alert_service import broadcast_event
+            await broadcast_event(
+                is_alert=False,
+                severity="info",
+                event_type="AccessControllerEvent",
+                description=f"Registered vehicle at entry gate: plate {plate}",
+                camera_id=event.camera_id,
+                zone_id=gate,
+                plate_number=plate,
+                snapshot_path=event.snapshot_path,
+                triggered_at=event_time
+            )
+        else:
+            logger.info(f"[UC4] Triggering alert for unknown/unregistered vehicle: {plate}")
+            await create_alert(
+                db=db,
+                alert_type="unknown_vehicle",
+                camera_id=event.camera_id,
+                zone_id=gate,
+                event_type="AccessControllerEvent",
+                description=f"Unregistered vehicle at entry gate: plate {plate}",
+                plate_number=plate,
+                snapshot_path=event.snapshot_path,
+            )
+        return
+
+    # ── EXIT: log immediately, no confirmation needed ─────────────────────
     log_entry = EntryExitLog(
         plate_number=plate,
         vehicle_id=vehicle.id if vehicle else None,
@@ -132,70 +229,53 @@ async def handle_anpr_event(event: ParsedCameraEvent, db: Session):
         created_at=facility_now_naive(),
     )
 
-    if gate == "entry":
-        parking_session_service.open_session(
-            db,
-            plate_number=plate,
-            event_time=event_time,
-            camera_id=event.camera_id,
-            snapshot_path=event.snapshot_path,
-            vehicle=vehicle,
-        )
-
     # UC2: Calculation of Parking Duration on Exit
-    if gate == "exit":
-        matching_entry = (
-            db.query(EntryExitLog)
-            .filter(
-                EntryExitLog.plate_number == plate,
-                EntryExitLog.gate == "entry",
-                EntryExitLog.matched_entry_id.is_(None)
-            )
-            .order_by(EntryExitLog.event_time.desc())
-            .first()
+    matching_entry = (
+        db.query(EntryExitLog)
+        .filter(
+            EntryExitLog.plate_number == plate,
+            EntryExitLog.gate == "entry",
+            EntryExitLog.matched_entry_id.is_(None)
         )
+        .order_by(EntryExitLog.event_time.desc())
+        .first()
+    )
 
-        if matching_entry:
-            # event_time is already naive facility-local (normalized above);
-            # matching_entry may still be tz-aware if stored before the fix,
-            # so strip it defensively. Convert to facility tz first to keep
-            # the wall-clock value, matching the new DB convention.
-            t2 = matching_entry.event_time
-            if t2.tzinfo is not None:
-                t2 = t2.astimezone(facility_tz()).replace(tzinfo=None)
+    if matching_entry:
+        t2 = matching_entry.event_time
+        if t2.tzinfo is not None:
+            t2 = t2.astimezone(facility_tz()).replace(tzinfo=None)
 
-            duration_seconds = int((event_time - t2).total_seconds())
-            log_entry.parking_duration = max(0, duration_seconds)
+        duration_seconds = int((event_time - t2).total_seconds())
+        log_entry.parking_duration = max(0, duration_seconds)
 
-            db.add(log_entry)
-            db.flush()
+        db.add(log_entry)
+        db.flush()
 
-            log_entry.matched_entry_id = matching_entry.id
-            matching_entry.matched_entry_id = log_entry.id
+        log_entry.matched_entry_id = matching_entry.id
+        matching_entry.matched_entry_id = log_entry.id
 
-            # Calculate minutes and seconds for a clearer log
-            mins, secs = divmod(duration_seconds, 60)
-            logger.info(f"[UC2] MATCH FOUND! Vehicle {plate} parked for {mins}m {secs}s")
-        else:
-            logger.warning(f"[UC2] No matching entry found for vehicle {plate}")
+        mins, secs = divmod(duration_seconds, 60)
+        logger.info(f"[UC2] MATCH FOUND! Vehicle {plate} parked for {mins}m {secs}s")
+    else:
+        logger.warning(f"[UC2] No matching entry found for vehicle {plate}")
 
-        parking_session_service.close_session(
-            db,
-            plate_number=plate,
-            event_time=event_time,
-            camera_id=event.camera_id,
-            snapshot_path=event.snapshot_path,
-        )
+    parking_session_service.close_session(
+        db,
+        plate_number=plate,
+        event_time=event_time,
+        camera_id=event.camera_id,
+        snapshot_path=event.snapshot_path,
+    )
 
-    # UC4: Clear logic for single notification/alert
+    # UC4
     if vehicle and vehicle.is_registered:
-        # Registered vehicle — send single 'info' notification via unified broadcast
         from app.services.alert_service import broadcast_event
         await broadcast_event(
             is_alert=False,
             severity="info",
             event_type="AccessControllerEvent",
-            description=f"Registered vehicle at {gate} gate: plate {plate}",
+            description=f"Registered vehicle at exit gate: plate {plate}",
             camera_id=event.camera_id,
             zone_id=gate,
             plate_number=plate,
@@ -203,7 +283,6 @@ async def handle_anpr_event(event: ParsedCameraEvent, db: Session):
             triggered_at=event_time
         )
     else:
-        # Unregistered vehicle — send single 'critical' alert
         logger.info(f"[UC4] Triggering alert for unknown/unregistered vehicle: {plate}")
         await create_alert(
             db=db,
@@ -211,7 +290,7 @@ async def handle_anpr_event(event: ParsedCameraEvent, db: Session):
             camera_id=event.camera_id,
             zone_id=gate,
             event_type="AccessControllerEvent",
-            description=f"Unregistered vehicle at {gate} gate: plate {plate}",
+            description=f"Unregistered vehicle at exit gate: plate {plate}",
             plate_number=plate,
             snapshot_path=event.snapshot_path,
         )

--- a/app/services/occupancy_service.py
+++ b/app/services/occupancy_service.py
@@ -214,6 +214,9 @@ async def handle_occupancy_event(event: ParsedCameraEvent, db: Session):
         if cam_id == "CAM-03":
             await _update_zone_count(settings.GARAGE_TOTAL_ZONE, cam_id,  1 * multiplier, db, event.snapshot_path)
             await _update_zone_count(settings.B1_PARKING_ZONE,   cam_id,  1 * multiplier, db, event.snapshot_path)
+            if multiplier == 1:  # entry direction only — confirm pending ANPR
+                from app.services.entry_exit_service import confirm_pending_entry
+                await confirm_pending_entry(db)
         elif cam_id == "CAM-08":
             await _update_zone_count(settings.GARAGE_TOTAL_ZONE, cam_id, -1 * multiplier, db, event.snapshot_path)
             await _update_zone_count(settings.B1_PARKING_ZONE,   cam_id, -1 * multiplier, db, event.snapshot_path)

--- a/tests/test_entry_exit_service.py
+++ b/tests/test_entry_exit_service.py
@@ -9,7 +9,11 @@ import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 from datetime import datetime, UTC, timedelta
 from app.models.vehicle import Vehicle
-from app.services.entry_exit_service import handle_anpr_event
+from app.services.entry_exit_service import (
+    handle_anpr_event,
+    confirm_pending_entry,
+    _pending_entries,
+)
 from app.services.event_parser import ParsedCameraEvent
 
 def make_anpr_event(plate="ABC-1234", gate="entry", trigger_time=None):
@@ -29,12 +33,15 @@ def make_anpr_event(plate="ABC-1234", gate="entry", trigger_time=None):
     )
 
 class TestEntryExitService:
+    def setup_method(self):
+        _pending_entries.clear()
+
     @pytest.mark.asyncio
     @patch("app.services.entry_exit_service.create_alert", new_callable=AsyncMock)
     @patch("app.services.entry_exit_service.parking_session_service.open_session")
     @patch("app.services.entry_exit_service.vehicle_service")
     async def test_entry_event_creates_log(self, mock_vs, mock_open_session, mock_alert):
-        """UC1: Entry event should create a log record in the database."""
+        """UC1: ANPR entry defers DB write to pending cache; CAM-03 confirm writes the log."""
         placeholder_vehicle = MagicMock(spec=Vehicle)
         placeholder_vehicle.id = 42
         placeholder_vehicle.plate_number = "ABC-1234"
@@ -42,14 +49,21 @@ class TestEntryExitService:
         placeholder_vehicle.owner_name = "Unknown"
         placeholder_vehicle.is_employee = False
         placeholder_vehicle.is_registered = False
-        mock_vs.lookup_vehicle.return_value = None  # Unknown vehicle
         mock_vs.ensure_unregistered_vehicle.return_value = placeholder_vehicle
         db = MagicMock()
         query_chain = db.query.return_value
         query_chain.filter.return_value = query_chain
-        query_chain.first.side_effect = [None, None]
+        query_chain.order_by.return_value = query_chain
+        query_chain.first.return_value = None  # no dedup hit, no anti-bounce hit
 
+        # Phase 1: ANPR fires — no DB write yet, plate sits in pending cache
         await handle_anpr_event(make_anpr_event(), db)
+
+        db.add.assert_not_called()
+        assert "ABC-1234" in _pending_entries
+
+        # Phase 2: CAM-03 confirms entry — log is written to DB
+        await confirm_pending_entry(db)
 
         db.add.assert_called_once()
         log = db.add.call_args[0][0]
@@ -66,6 +80,7 @@ class TestEntryExitService:
             snapshot_path=None,
             vehicle=placeholder_vehicle,
         )
+        assert "ABC-1234" not in _pending_entries
 
     @pytest.mark.asyncio
     @patch("app.services.entry_exit_service.create_alert", new_callable=AsyncMock)
@@ -80,10 +95,9 @@ class TestEntryExitService:
 
     @pytest.mark.asyncio
     @patch("app.services.entry_exit_service.create_alert", new_callable=AsyncMock)
-    @patch("app.services.entry_exit_service.parking_session_service.open_session")
     @patch("app.services.entry_exit_service.vehicle_service")
-    async def test_unknown_vehicle_triggers_alert(self, mock_vs, mock_open_session, mock_alert):
-        """UC4: Detecting an unregistered vehicle must trigger an alert."""
+    async def test_unknown_vehicle_triggers_alert(self, mock_vs, mock_alert):
+        """UC4: Unregistered vehicle at entry must trigger an alert (fires before CAM-03 confirm)."""
         placeholder_vehicle = MagicMock(spec=Vehicle)
         placeholder_vehicle.id = 42
         placeholder_vehicle.plate_number = "ABC-1234"
@@ -91,12 +105,12 @@ class TestEntryExitService:
         placeholder_vehicle.owner_name = "Unknown"
         placeholder_vehicle.is_employee = False
         placeholder_vehicle.is_registered = False
-        mock_vs.lookup_vehicle.return_value = None
         mock_vs.ensure_unregistered_vehicle.return_value = placeholder_vehicle
         db = MagicMock()
         query_chain = db.query.return_value
         query_chain.filter.return_value = query_chain
-        query_chain.first.side_effect = [None, None]
+        query_chain.order_by.return_value = query_chain
+        query_chain.first.return_value = None  # no dedup, no anti-bounce
 
         await handle_anpr_event(make_anpr_event(), db)
 
@@ -107,9 +121,10 @@ class TestEntryExitService:
 
     @pytest.mark.asyncio
     @patch("app.services.alert_service.broadcast_event", new_callable=AsyncMock)
+    @patch("app.services.entry_exit_service.parking_session_service.close_session")
     @patch("app.services.entry_exit_service.create_alert", new_callable=AsyncMock)
     @patch("app.services.entry_exit_service.vehicle_service")
-    async def test_existing_unregistered_vehicle_still_triggers_alert(self, mock_vs, mock_alert, mock_broadcast):
+    async def test_existing_unregistered_vehicle_still_triggers_alert(self, mock_vs, mock_alert, mock_close_session, mock_broadcast):
         vehicle = MagicMock(spec=Vehicle)
         vehicle.id = 7
         vehicle.plate_number = "ABC-1234"
@@ -117,12 +132,13 @@ class TestEntryExitService:
         vehicle.owner_name = "Unknown"
         vehicle.is_employee = False
         vehicle.is_registered = False
-        mock_vs.lookup_vehicle.return_value = vehicle
+        mock_vs.ensure_unregistered_vehicle.return_value = vehicle
 
         db = MagicMock()
         query_chain = db.query.return_value
         query_chain.filter.return_value = query_chain
-        query_chain.first.side_effect = [None, None]
+        query_chain.order_by.return_value = query_chain
+        query_chain.first.return_value = None  # no dedup, no matching entry
 
         await handle_anpr_event(make_anpr_event(gate="exit"), db)
 

--- a/tests/test_event_parser.py
+++ b/tests/test_event_parser.py
@@ -46,8 +46,12 @@ class TestXMLEventParsing:
           </DetectionRegionEntry></DetectionRegionList>
         </EventNotificationAlert>"""
 
+        from unittest.mock import patch
         from app.config import settings
-        event = parse_camera_event(xml, settings.CAM_35_IP, "application/xml")
+        fake_ip = "192.168.99.35"
+        fake_map = {**settings.CAMERA_IP_MAP, fake_ip: "CAM-35"}
+        with patch.object(settings, "CAMERA_IP_MAP", fake_map):
+            event = parse_camera_event(xml, fake_ip, "application/xml")
         assert event.event_type == "regionEntrance"
         assert event.region_id == "parking-row-A"
         assert event.camera_id == "CAM-35"

--- a/tests/test_occupancy_simulation.py
+++ b/tests/test_occupancy_simulation.py
@@ -19,7 +19,7 @@ import sys
 import os
 import time
 import logging
-from datetime import datetime
+from datetime import datetime, UTC
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/test_parking_session_service.py
+++ b/tests/test_parking_session_service.py
@@ -103,6 +103,7 @@ def test_bind_and_unbind_slot(db):
     session = parking_session_service.bind_slot(
         db,
         plate_number="ABC-1234",
+        slot_id="SLOT-B1-12",
         slot_number="B1-12",
         zone_id="B1-PARKING",
         zone_name=None,
@@ -132,6 +133,7 @@ def test_bind_slot_requires_open_session(db):
         parking_session_service.bind_slot(
             db,
             plate_number="ABC-1234",
+            slot_id="SLOT-B1-12",
             slot_number="B1-12",
             zone_id="B1-PARKING",
             zone_name=None,

--- a/tests/test_parking_stats.py
+++ b/tests/test_parking_stats.py
@@ -2,7 +2,7 @@
 import sys
 import os
 import pytest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from unittest.mock import AsyncMock, patch
@@ -13,6 +13,8 @@ from app.database import Base
 from app.models.entry_exit_log import EntryExitLog
 from app.services.entry_exit_service import handle_anpr_event
 from app.services.event_parser import ParsedCameraEvent
+from app.models.entry_exit_log import EntryExitLog as _EntryExitLogModel
+from app.config import facility_tz
 from app.routers.parking_stats import get_avg_parking_time, get_daily_stats
 
 # Setup in-memory SQLite for testing
@@ -49,19 +51,28 @@ def db():
 async def test_parking_duration_calculation(db):
     """Verify that exit event matches entry and calculates duration."""
     plate = "TEST-123"
-    entry_time = datetime.now(UTC) - timedelta(minutes=30)
+    # Naive facility-local timestamps (DB convention)
+    entry_time_naive = (datetime.now(UTC) - timedelta(minutes=30)).astimezone(facility_tz()).replace(tzinfo=None)
     exit_time = datetime.now(UTC)
-    
-    # 1. Entry Event
-    entry_event = make_anpr_event("CAM-ENTRY", plate, "entry", entry_time)
-    with patch("app.services.entry_exit_service.create_alert", new_callable=AsyncMock):
-        await handle_anpr_event(entry_event, db)
+
+    # Seed the entry log directly — this test covers duration/stats logic,
+    # not the two-phase ANPR detection flow (covered by test_entry_exit_service).
+    db.add(_EntryExitLogModel(
+        plate_number=plate,
+        vehicle_id=None,
+        vehicle_type="unknown",
+        gate="entry",
+        camera_id="CAM-ENTRY",
+        event_time=entry_time_naive,
+        created_at=entry_time_naive,
+    ))
     db.commit()
-    
-    # 2. Exit Event
+
+    # Exit Event — drives duration calculation and matching
     exit_event = make_anpr_event("CAM-EXIT", plate, "exit", exit_time)
     with patch("app.services.entry_exit_service.create_alert", new_callable=AsyncMock):
-        await handle_anpr_event(exit_event, db)
+        with patch("app.services.entry_exit_service.parking_session_service.close_session"):
+            await handle_anpr_event(exit_event, db)
     db.commit()
     
     # Verify records
@@ -76,7 +87,7 @@ async def test_parking_duration_calculation(db):
     assert exit_log.parking_duration == 1800 # 30 mins
     
     # 3. Verify Stats Endpoint logic
-    target_dt = entry_time.strftime("%Y-%m-%d")
+    target_dt = entry_time_naive.strftime("%Y-%m-%d")
     stats = get_avg_parking_time(target_date=target_dt, db=db)
     assert stats["avg_parking_minutes"] == 30.0
     


### PR DESCRIPTION
- entry_exit_service: ANPR at entry gate now defers DB write to _pending_entries cache; confirm_pending_entry() is called by occupancy_service when CAM-03 fires (entry direction) to flush the oldest pending plate to entry_exit_log. Exits remain immediate.
- occupancy_service: call confirm_pending_entry on CAM-03 entry events
- tests: fix 15 pre-existing failures across 5 test files
    - add missing UTC imports (test_occupancy_simulation, test_parking_stats)
    - rewrite test_entry_event_creates_log for two-phase flow
    - add order_by mock to prevent anti-bounce false-positive in unit tests
    - mock close_session in exit tests to avoid exhausting side_effect list
    - patch CAMERA_IP_MAP for CAM-35 test instead of relying on .env
    - add missing slot_id arg to bind_slot calls
    - seed entry log directly in test_parking_duration_calculation