### PR TITLE
fix: restore immediate entry writes + add USE_CAM03_ENTRY_CONFIRMATIO…

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -306,6 +306,7 @@ class Settings(BaseSettings):
     FORWARD_DIRECTION_FIELD: str = "B-to-A"  # Primary flow (entry/exit/transition)
     USE_EXIT_DIRECTION_VALIDATION: bool = True
     USE_EXIT_CONFIRM_WINDOW: bool = True
+    USE_CAM03_ENTRY_CONFIRMATION: bool = False
 
     # ── Anti-bounce on entry events (UC1) ────────────────────────────────
     # Suppress an entry-camera ANPR firing if the same plate had an exit

--- a/app/services/entry_exit_service.py
+++ b/app/services/entry_exit_service.py
@@ -176,20 +176,44 @@ async def handle_anpr_event(event: ParsedCameraEvent, db: Session):
 
     logger.info(f"[UC1] Gate={gate} | Plate={plate} | Type={vehicle_type}")
 
-    # ── ENTRY: defer DB write until CAM-03 confirms car actually entered ──
+    # ── ENTRY ─────────────────────────────────────────────────────────────
     if gate == "entry":
-        _cleanup_pending()
-        _pending_entries[plate] = {
-            "plate": plate,
-            "camera_id": event.camera_id,
-            "event_time": event_time,
-            "snapshot_path": event.snapshot_path,
-            "vehicle": vehicle,
-            "vehicle_type": vehicle_type,
-        }
-        logger.info(f"[UC1] ANPR entry pending CAM-03 confirmation: plate={plate}")
+        if settings.USE_CAM03_ENTRY_CONFIRMATION:
+            # Defer DB write — CAM-03 linedetection will call confirm_pending_entry()
+            _cleanup_pending()
+            _pending_entries[plate] = {
+                "plate": plate,
+                "camera_id": event.camera_id,
+                "event_time": event_time,
+                "snapshot_path": event.snapshot_path,
+                "vehicle": vehicle,
+                "vehicle_type": vehicle_type,
+            }
+            logger.info(f"[UC1] ANPR entry pending CAM-03 confirmation: plate={plate}")
+        else:
+            # Immediate write (USE_CAM03_ENTRY_CONFIRMATION=False, the default)
+            log_entry = EntryExitLog(
+                plate_number=plate,
+                vehicle_id=vehicle.id if vehicle else None,
+                vehicle_type=vehicle_type,
+                gate="entry",
+                camera_id=event.camera_id,
+                event_time=event_time,
+                snapshot_path=event.snapshot_path,
+                created_at=facility_now_naive(),
+            )
+            db.add(log_entry)
+            parking_session_service.open_session(
+                db,
+                plate_number=plate,
+                event_time=event_time,
+                camera_id=event.camera_id,
+                snapshot_path=event.snapshot_path,
+                vehicle=vehicle,
+            )
+            logger.info(f"[UC1] Entry LOGGED immediately: plate={plate}")
 
-        # UC4: alert/notification fires immediately even though DB write is deferred
+        # UC4: alert/notification fires regardless of two-phase mode
         if vehicle and vehicle.is_registered:
             from app.services.alert_service import broadcast_event
             await broadcast_event(

--- a/tests/test_entry_exit_service.py
+++ b/tests/test_entry_exit_service.py
@@ -41,7 +41,7 @@ class TestEntryExitService:
     @patch("app.services.entry_exit_service.parking_session_service.open_session")
     @patch("app.services.entry_exit_service.vehicle_service")
     async def test_entry_event_creates_log(self, mock_vs, mock_open_session, mock_alert):
-        """UC1: ANPR entry defers DB write to pending cache; CAM-03 confirm writes the log."""
+        """UC1: ANPR entry writes log immediately when USE_CAM03_ENTRY_CONFIRMATION=False (default)."""
         placeholder_vehicle = MagicMock(spec=Vehicle)
         placeholder_vehicle.id = 42
         placeholder_vehicle.plate_number = "ABC-1234"
@@ -55,6 +55,42 @@ class TestEntryExitService:
         query_chain.filter.return_value = query_chain
         query_chain.order_by.return_value = query_chain
         query_chain.first.return_value = None  # no dedup hit, no anti-bounce hit
+
+        await handle_anpr_event(make_anpr_event(), db)
+
+        db.add.assert_called_once()
+        log = db.add.call_args[0][0]
+        assert log.plate_number == "ABC-1234"
+        assert log.gate == "entry"
+        assert log.vehicle_id == 42
+        assert log.vehicle_type == "unknown"
+        mock_vs.ensure_unregistered_vehicle.assert_called_once_with(db, "ABC-1234")
+        mock_open_session.assert_called_once()
+        assert "ABC-1234" not in _pending_entries
+
+    @pytest.mark.asyncio
+    @patch("app.services.entry_exit_service.settings")
+    @patch("app.services.entry_exit_service.create_alert", new_callable=AsyncMock)
+    @patch("app.services.entry_exit_service.parking_session_service.open_session")
+    @patch("app.services.entry_exit_service.vehicle_service")
+    async def test_entry_two_phase_flow(self, mock_vs, mock_open_session, mock_alert, mock_settings):
+        """UC1: With USE_CAM03_ENTRY_CONFIRMATION=True, entry defers until CAM-03 confirms."""
+        mock_settings.USE_CAM03_ENTRY_CONFIRMATION = True
+        mock_settings.CAMERAS = {"CAM-ENTRY": {"gate": "entry"}}
+        mock_settings.ENTRY_ANTIBOUNCE_SECONDS = 30
+        placeholder_vehicle = MagicMock(spec=Vehicle)
+        placeholder_vehicle.id = 42
+        placeholder_vehicle.plate_number = "ABC-1234"
+        placeholder_vehicle.vehicle_type = "unknown"
+        placeholder_vehicle.owner_name = "Unknown"
+        placeholder_vehicle.is_employee = False
+        placeholder_vehicle.is_registered = False
+        mock_vs.ensure_unregistered_vehicle.return_value = placeholder_vehicle
+        db = MagicMock()
+        query_chain = db.query.return_value
+        query_chain.filter.return_value = query_chain
+        query_chain.order_by.return_value = query_chain
+        query_chain.first.return_value = None
 
         # Phase 1: ANPR fires — no DB write yet, plate sits in pending cache
         await handle_anpr_event(make_anpr_event(), db)
@@ -70,16 +106,7 @@ class TestEntryExitService:
         assert log.plate_number == "ABC-1234"
         assert log.gate == "entry"
         assert log.vehicle_id == 42
-        assert log.vehicle_type == "unknown"
-        mock_vs.ensure_unregistered_vehicle.assert_called_once_with(db, "ABC-1234")
-        mock_open_session.assert_called_once_with(
-            db,
-            plate_number="ABC-1234",
-            event_time=log.event_time,
-            camera_id="CAM-ENTRY",
-            snapshot_path=None,
-            vehicle=placeholder_vehicle,
-        )
+        mock_open_session.assert_called_once()
         assert "ABC-1234" not in _pending_entries
 
     @pytest.mark.asyncio


### PR DESCRIPTION
…N toggle

Two-phase entry (f041b67) silently dropped all entries in production because CAM-03 was not firing to confirm them. Add USE_CAM03_ENTRY_CONFIRMATION flag (default False) so entries write immediately on ANPR — old behavior restored. Set True in .env only when CAM-03 is reliably deployed.