### PR TITLE
fix: UC4 alert only for registered vehicles

### DIFF
--- a/app/services/entry_exit_service.py
+++ b/app/services/entry_exit_service.py
@@ -214,7 +214,7 @@ async def handle_anpr_event(event: ParsedCameraEvent, db: Session):
             logger.info(f"[UC1] Entry LOGGED immediately: plate={plate}")
 
         # UC4: alert/notification fires regardless of two-phase mode
-        if vehicle:
+        if vehicle and vehicle.is_registered:
             from app.services.alert_service import broadcast_event
             await broadcast_event(
                 is_alert=False,
@@ -293,7 +293,7 @@ async def handle_anpr_event(event: ParsedCameraEvent, db: Session):
     )
 
     # UC4
-    if vehicle:
+    if vehicle and vehicle.is_registered:
         from app.services.alert_service import broadcast_event
         await broadcast_event(
             is_alert=False,


### PR DESCRIPTION
## Changes
- Entry gate (UC4): broadcast info event only when ehicle.is_registered is True, otherwise trigger an unknown_vehicle alert
- Exit gate (UC4): same fix — unregistered/auto-added vehicles now correctly route to the alert path

## Context
Previously the condition was if vehicle: which always evaluated to True for auto-added vehicles (created by ensure_unregistered_vehicle), skipping the alert for unregistered plates.