### PR TITLE
fix(occupancy): capacity_exceeded only on overflow + accurate description

### DIFF
--- a/app/services/occupancy_service.py
+++ b/app/services/occupancy_service.py
@@ -1,8 +1,10 @@
 # app/services/occupancy_service.py
 from datetime import datetime, UTC
-from sqlalchemy import update, func, case
+from typing import Optional
+from sqlalchemy import update, func, case, text
 from sqlalchemy.orm import Session
 from app.models.zone_occupancy import ZoneOccupancy
+from app.models.parking_session import ParkingSession
 from app.services.event_parser import ParsedCameraEvent
 from app.services.alert_service import create_alert
 from app.config import settings, facility_now_naive
@@ -23,6 +25,50 @@ CACHE_TTL_SECONDS = settings.EVENT_STREAM_SUPPRESS_SECONDS
 # repeatedly while a zone stays full. Key: zone_id, Value: last alert timestamp.
 _capacity_alert_cache: dict[str, float] = {}
 CAPACITY_ALERT_COOLDOWN = settings.CAPACITY_ALERT_COOLDOWN_SECONDS
+
+
+async def _real_capacity_state(db: Session, zone_id: str, floor: Optional[str]) -> tuple[int, int]:
+    """Return `(real_max_capacity, real_occupancy)` for a zone, sourced from
+    the same tables the gateway dashboard reads — so the alert text agrees
+    with what operators see on the cards.
+
+    `real_max_capacity` counts `parking_slots` rows (monitored + unmonitored)
+    excluding violation-zone slots — the true floor size, not the line-crossing
+    aggregate which can drift.
+
+    `real_occupancy` is the count of open `parking_sessions` rows — physical
+    cars in the garage right now (not the line-crossing tick count).
+
+    Scope:
+      - `GARAGE_TOTAL_ZONE` or unknown floor → garage-wide counts.
+      - per-floor zone with a configured `floor` → floor-scoped counts.
+
+    Defensive: the `parking_slots` table isn't owned by PMS-AI's Alembic
+    migrations (the gateway provisions it via `sql/bootstrap.sql`), so on
+    test rigs or fresh deployments where the table doesn't exist yet, the
+    query 500s. We catch + return (0, occ) so the trigger short-circuits
+    (no alert) rather than aborting the whole occupancy update.
+    """
+    try:
+        if zone_id == settings.GARAGE_TOTAL_ZONE or not floor:
+            real_max = db.execute(
+                text("SELECT COUNT(*) FROM parking_slots WHERE is_violation_zone = 0")
+            ).scalar() or 0
+        else:
+            real_max = db.execute(
+                text("SELECT COUNT(*) FROM parking_slots WHERE floor = :f AND is_violation_zone = 0"),
+                {"f": floor},
+            ).scalar() or 0
+    except Exception as e:
+        logger.debug(f"[UC3] parking_slots unavailable for {zone_id}: {e}; treating real_max as 0")
+        real_max = 0
+
+    sessions_q = db.query(func.count(ParkingSession.id)).filter(ParkingSession.status == "open")
+    if zone_id != settings.GARAGE_TOTAL_ZONE and floor:
+        sessions_q = sessions_q.filter(ParkingSession.floor == floor)
+    real_occupancy = sessions_q.scalar() or 0
+
+    return int(real_max), int(real_occupancy)
 
 
 async def push_db_update(db: Session, zone_id: str, delta: int):
@@ -86,17 +132,25 @@ async def _update_zone_count(zone_id: str, camera_id: str, delta: int, db: Sessi
     # The atomic func.max() in push_db_update now handles this.
 
     zone.last_updated = facility_now_naive()
-    occupancy_ratio = (zone.current_count / zone.max_capacity) if zone.max_capacity > 0 else 0
-    pct = int(occupancy_ratio * 100)
+    line_pct = int((zone.current_count / zone.max_capacity) * 100) if zone.max_capacity > 0 else 0
+    logger.info(f"[UC3] {zone_id} Updated via Push: {zone.current_count}/{zone.max_capacity} ({line_pct}% line-crossing)")
 
-    logger.info(f"[UC3] {zone_id} Updated via Push: {zone.current_count}/{zone.max_capacity} ({pct}%)")
-
-    if occupancy_ratio >= 1:
+    # Capacity-exceeded alert — sourced from the true state (parking_slots +
+    # open parking_sessions), not the line-crossing aggregate. The aggregate
+    # is just the wake-up tick.
+    #
+    # Trigger: strict exceed. At occupancy == capacity ("full") no alert
+    # fires. An alert means there are MORE cars than slots — surplus the
+    # garage can't actually hold.
+    real_max, real_occupancy = await _real_capacity_state(db, zone_id, zone.floor)
+    if real_max > 0 and real_occupancy > real_max:
+        real_pct = int((real_occupancy / real_max) * 100)
         now_ts = facility_now_naive().timestamp()
         cooldown_key = (camera_id, zone_id)
         last_alert_ts = _capacity_alert_cache.get(cooldown_key, 0)
         if now_ts - last_alert_ts >= CAPACITY_ALERT_COOLDOWN:
             _capacity_alert_cache[cooldown_key] = now_ts
+            scope = "Garage" if zone_id == settings.GARAGE_TOTAL_ZONE else f"Floor {zone.floor or zone_id}"
             await create_alert(
                 db,
                 alert_type="capacity_exceeded",
@@ -104,7 +158,10 @@ async def _update_zone_count(zone_id: str, camera_id: str, delta: int, db: Sessi
                 zone_id=zone_id,
                 zone_name=zone.zone_name,
                 event_type="occupancy_update",
-                description=f"Zone {zone_id} is nearly full: {pct}% ({zone.current_count}/{zone.max_capacity})",
+                description=(
+                    f"{scope} capacity exceeded: {real_pct}% "
+                    f"({real_occupancy} parked / {real_max} slots)"
+                ),
                 snapshot_path=snapshot_path,
             )
         else:

--- a/tests/test_occupancy_service.py
+++ b/tests/test_occupancy_service.py
@@ -154,29 +154,56 @@ class TestOccupancyService:
         assert get_count(db, settings.B1_PARKING_ZONE) == 0
 
     @pytest.mark.asyncio
-    async def test_alert_triggered_at_capacity(self, db):
-        """UC3: Alert fires when occupancy reaches or exceeds 100% capacity."""
+    async def test_alert_not_triggered_at_exact_capacity(self, db):
+        """UC3: At exactly 100% occupancy (=full) the alert does NOT fire.
+        `capacity_exceeded` is reserved for strict overflow (>100%) — full is
+        a normal operating state, not an exception."""
         seed_zones(db, total=9, b1=9, b2=0, capacity=10)
 
-        with patch("app.services.occupancy_service.create_alert", new_callable=AsyncMock) as mock_alert:
+        with patch("app.services.occupancy_service.create_alert", new_callable=AsyncMock) as mock_alert, \
+             patch("app.services.occupancy_service._real_capacity_state",
+                   new_callable=AsyncMock, return_value=(10, 10)):
             await handle_occupancy_event(make_event("1", "CAM-03"), db)
         db.commit()
 
-        # Alert should fire for both GARAGE-TOTAL and B1 (both hit 10/10 = 100%)
+        # Real-source check says 10 parked / 10 slots = full but not exceeded.
+        mock_alert.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_alert_triggered_when_exceeded(self, db):
+        """UC3: Alert fires when real parked vehicles strictly exceed slots."""
+        seed_zones(db, total=10, b1=10, b2=0, capacity=10)
+
+        with patch("app.services.occupancy_service.create_alert", new_callable=AsyncMock) as mock_alert, \
+             patch("app.services.occupancy_service._real_capacity_state",
+                   new_callable=AsyncMock, return_value=(10, 11)):
+            await handle_occupancy_event(make_event("1", "CAM-03"), db)
+        db.commit()
+
         assert mock_alert.call_count >= 1
-        # Verify at least one call has the right alert type
         alert_types = [
             call.kwargs.get("alert_type", call.args[1] if len(call.args) > 1 else None)
             for call in mock_alert.call_args_list
         ]
         assert "capacity_exceeded" in alert_types
+        # Description should carry the real numbers, not line-crossing.
+        descriptions = [
+            call.kwargs.get("description", "")
+            for call in mock_alert.call_args_list
+            if call.kwargs.get("alert_type") == "capacity_exceeded"
+        ]
+        assert any("11 parked / 10 slots" in d for d in descriptions), (
+            f"description should include real counts; got {descriptions!r}"
+        )
 
     @pytest.mark.asyncio
     async def test_alert_not_triggered_below_threshold(self, db):
-        """No alert should be sent if occupancy is below 100%."""
+        """No alert when real occupancy is comfortably below capacity."""
         seed_zones(db, total=5, b1=5, b2=0, capacity=10)
 
-        with patch("app.services.occupancy_service.create_alert", new_callable=AsyncMock) as mock_alert:
+        with patch("app.services.occupancy_service.create_alert", new_callable=AsyncMock) as mock_alert, \
+             patch("app.services.occupancy_service._real_capacity_state",
+                   new_callable=AsyncMock, return_value=(10, 5)):
             await handle_occupancy_event(make_event("1", "CAM-03"), db)
         db.commit()
 


### PR DESCRIPTION
## Summary

QA round 2 items 8 + 9 (paired in the gateway's planning doc).

**Item 9 — strict-exceed trigger.** `_update_zone_count` was firing `capacity_exceeded` whenever `occupancy_ratio >= 1`. The QA call: that's the wrong semantic — at exactly 100% the garage is *full*, which is a normal operating state, not an exception. The alert should only fire on actual overflow (more cars than slots).

Trigger changed to strict `>`. At exact capacity: no alert. At capacity+1: alert.

**Item 8 — accurate description text.** The old description was \"Zone X is nearly full: 100% (13/13)\" — wrong on two counts:

1. The numerator (`zone.current_count`) is the line-crossing aggregate, which drifts from reality as missed entries / exits accumulate.
2. The denominator (`zone.max_capacity`) is a config value, not the true slot inventory.

New description reads the source-of-truth tables — the same ones the gateway dashboard reads — so the alert text agrees with what operators see on the cards:

- `max_capacity` = `COUNT(parking_slots WHERE floor=X AND is_violation_zone=0)` (true floor size, monitored + unmonitored)
- `occupancy` = `COUNT(parking_sessions WHERE status='open' AND floor=X)` (physical cars in the garage right now)

For `GARAGE_TOTAL_ZONE` the scope is garage-wide. New format: `Floor B1 capacity exceeded: 108% (14 parked / 13 slots)`.

The line-crossing event still drives the wake-up — the alert is re-checked whenever a car crosses a counter line — but the trigger condition and the description text both use the real state.

## Schema-compat note

`parking_slots` is provisioned by the gateway's `sql/bootstrap.sql`, not PMS-AI's Alembic. On rigs where the table isn't there yet (the SQLite-based test fixture; first-boot deployments before the gateway runs bootstrap), the new helper catches the error and returns `real_max = 0` — the trigger short-circuits, no alert fires, the occupancy update completes normally. No crashes inside the savepoint.

## Companion PR

Pairs with API-Gateway PR #11 (\`feat/qa-round-2\`) which delivered the rest of QA round 2 — dashboard `total_slots`, coverage-aware `available_slots` + `coverage_note`, slot violation indicators (`has_active_violation` / `active_violation_type` / `active_violation_severity`), and the relaxed employee-id validator.

## Test plan

- [x] Renamed `test_alert_triggered_at_capacity` → `test_alert_not_triggered_at_exact_capacity`: seeds zones at the boundary, mocks `_real_capacity_state` → `(10, 10)`, asserts **no** alert fires.
- [x] New `test_alert_triggered_when_exceeded`: mocks `(10, 11)`, asserts alert fires AND description contains `\"11 parked / 10 slots\"`.
- [x] `test_alert_not_triggered_below_threshold`: mocks `(10, 5)`, no alert.
- [x] `tests/test_occupancy_service.py` — 7/7 pass.
- [x] Full suite: 57 passed, 2 pre-existing unrelated failures on `develop` (`test_event_parser.py::test_fielddetection_event`, `test_anpr_exit_event`) untouched.

### Manual verification against a real DB

- [ ] Set up a deployment where `parking_slots` has 13 rows on floor B1 and `parking_sessions` has 13 open rows for B1 (capacity reached). No alert should fire as line-crossings keep arriving.
- [ ] Add a 14th open `parking_sessions` row. The next CAM-03 line-crossing event should fire `capacity_exceeded` with description `\"Floor B1 capacity exceeded: 107% (14 parked / 13 slots)\"`.
- [ ] On the gateway dashboard, the rendered alert should show the same numbers as the `parked_vehicles` and `total_slots` KPIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)