### PR TITLE
fix(vehicles): stop auto-filling title with classification labels

### DIFF
--- a/app/services/vehicle_service.py
+++ b/app/services/vehicle_service.py
@@ -21,11 +21,12 @@ logger = get_logger(__name__)
 
 
 def _default_title(vehicle_type: str) -> str:
-    if vehicle_type.lower() == "employee":
-        return "Employee"
-    if vehicle_type.lower() == "visitor":
-        return "Visitor"
-    return "Vehicle"
+    # ``title`` is a person's salutation (Mr./Mrs./Dr.) entered by the
+    # operator on the registration form, not a classification label.
+    # Auto-filling it from ``vehicle_type`` was overwriting real titles
+    # with "Vehicle"/"Employee"/"Visitor" on every gate event; leave the
+    # column blank when no human-entered value is supplied.
+    return ""
 
 
 def _default_is_employee(vehicle_type: str) -> bool:
@@ -100,7 +101,7 @@ def ensure_unregistered_vehicle(db: Session, plate_number: str) -> Vehicle:
     vehicle = Vehicle(
         plate_number=plate_number,
         owner_name="Unknown",
-        title="Vehicle",
+        title="",
         vehicle_type="unknown",
         employee_id=None,
         is_employee=False,


### PR DESCRIPTION
## Summary
- `vehicles.title` was being overwritten on every gate event with classification labels (`"Vehicle"`/`"Employee"`/`"Visitor"`), clobbering the salutation the operator enters via the registration form. Visible in the Gateway's `/vehicles/export/csv` output (Title column shows "Vehicle" instead of Mr./Mrs./Dr.).
- `_default_title()` (`app/services/vehicle_service.py:23`) now returns `""` for all `vehicle_type` values, with a comment explaining why so it doesn't get "fixed" back. Function kept for parallel structure with `_default_is_employee`.
- `ensure_unregistered_vehicle()` (`app/services/vehicle_service.py:103`) now sets `title=""` instead of `title="Vehicle"` for placeholder rows created when an unregistered plate is seen at the gate.

## Scope
Code-only fix. Existing rows in production will keep their bad titles — the client will run a one-shot manual cleanup (suggested: `UPDATE vehicles SET title = '' WHERE title IN ('Vehicle','Employee','Visitor');`).

## Test plan
- [x] `pytest tests/test_vehicle_service.py -v` → 12/12 passed (no existing test asserts on the old default labels, so no regression).
- [ ] After deploy, register a new plate without a title and confirm the Title column in `/vehicles/export/csv` stays blank.
- [ ] Trigger an unregistered plate at the gate (placeholder creation path) and confirm the new row has `title=''`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)