### PR TITLE
Fix V0 backend bug: reject OCR garbage plates (storage format unchanged)

### DIFF
--- a/app/services/event_parser.py
+++ b/app/services/event_parser.py
@@ -8,6 +8,7 @@ Handles multipart/form-data for image extraction.
 import json
 import os
 import re
+import unicodedata
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from datetime import datetime, UTC
@@ -347,6 +348,8 @@ def _normalize_plate(raw: str) -> Optional[str]:
         so OCR garbage like "6466466" or "1211" is rejected rather than stored
         (storing it is what produced the "plate mismatch" records on the
         dashboard, where the saved number didn't match the snapshot).
+      - reads with an implausible length, or interleaved layouts that aren't a
+        single digit-run + letter-run — also OCR failures.
     """
     if not raw:
         return None
@@ -356,14 +359,26 @@ def _normalize_plate(raw: str) -> Optional[str]:
     if raw in ("N/A", "NONE", "NULL", "", "UNKNOWN"):
         return None
 
+    # Fold non-ASCII Unicode digits (e.g. Arabic-Indic ٠-٩, U+0660–0669) to ASCII
+    # BEFORE the [^A-Z0-9] cleanup — otherwise a plate whose digits the camera
+    # reported in Arabic-Indic numerals would be stripped to letters-only and
+    # wrongly rejected. (Python's str.isdigit() already treats them as digits.)
+    raw = "".join(
+        str(unicodedata.digit(c)) if (not c.isascii() and c.isdigit()) else c
+        for c in raw
+    )
+
     # Plate "core" = letters and digits only (drop dashes, spaces, dots, …).
     core = re.sub(r"[^A-Z0-9]", "", raw)
     has_alpha = any(c.isalpha() for c in core)
     has_digit = any(c.isdigit() for c in core)
 
-    # Reject OCR misreads: a valid plate has BOTH letters and digits.
-    if not core or not (has_alpha and has_digit):
-        logger.debug(f"[ANPR] Rejected implausible plate (needs letters+digits): {raw!r}")
+    # Reject OCR misreads: a real plate has BOTH letters and digits and a sane
+    # length (Saudi plates are ~5–7 alphanumerics; cap at 8 for slack). This
+    # drops all-digit garbage ("6466466", "1211") and concatenated misreads
+    # ("99999999HUD") rather than storing them as fake plates.
+    if not (3 <= len(core) <= 8) or not (has_alpha and has_digit):
+        logger.debug(f"[ANPR] Rejected implausible plate: {raw!r}")
         return None
 
     # Single dash between the two runs, preserving the reported order.
@@ -374,9 +389,10 @@ def _normalize_plate(raw: str) -> Optional[str]:
     if m:
         return f"{m.group(1)}-{m.group(2)}"
 
-    # Interleaved / multi-segment (rare) — can't split cleanly; return the
-    # cleaned core so the value is still deterministic across reads.
-    return core
+    # Interleaved / multi-segment (e.g. "9H4U4D") isn't a real plate layout —
+    # treat it as an OCR failure rather than storing a dash-less oddball.
+    logger.debug(f"[ANPR] Rejected non-plate layout: {raw!r}")
+    return None
 
 
 def _parse_json_event(raw_body: bytes, camera_ip: str) -> ParsedCameraEvent:

--- a/app/services/event_parser.py
+++ b/app/services/event_parser.py
@@ -8,7 +8,6 @@ Handles multipart/form-data for image extraction.
 import json
 import os
 import re
-import unicodedata
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from datetime import datetime, UTC
@@ -330,69 +329,65 @@ def _parse_xml_event(raw_body: bytes, camera_ip: str) -> ParsedCameraEvent:
 
 def _normalize_plate(raw: str) -> Optional[str]:
     """
-    Canonicalize an ANPR plate read so the SAME physical plate always yields the
-    SAME string. Entry/exit dedup, open-session matching, and vehicle lookup all
-    compare ``plate_number`` by exact string equality, so any drift in
-    separators, spacing, or case silently creates duplicate sessions / vehicle
-    rows (the "registered twice" bug).
+    Normalize Saudi plate format from camera output to display format.
+    Examples: "9444HUD" → "HUD-9444",  "7800ERD" → "ERD-7800"
+    Returns None for unknown/partial/invalid plates.
 
-    Canonical form: upper-cased LETTERS-DIGITS with a SINGLE ``-`` between the
-    letter-run and the digit-run, regardless of the order the camera reported.
-    The DB convention is letters-first ("HUD-9444"); the frontend flips it to
-    digits-first ("9444-HUD") for display. Storing one consistent order is what
-    fixes the "registered twice" duplicates, so "9444HUD", "9444 HUD",
-    "9444-HUD", "HUD9444", and "HUD-9444" ALL canonicalize to "HUD-9444".
-
-    Returns None for reads that are not plausibly a plate:
-      - explicit failure tokens (N/A / NONE / NULL / UNKNOWN / empty)
-      - reads missing EITHER a letter or a digit — a real plate always has both,
-        so OCR garbage like "6466466" or "1211" is rejected rather than stored
-        (storing it is what produced the "plate mismatch" records on the
-        dashboard, where the saved number didn't match the snapshot).
-      - reads with an implausible length, or interleaved layouts that aren't a
-        single digit-run + letter-run — also OCR failures.
+    Plates are stored exactly as they always have been — this function does NOT
+    change the stored format (the frontend handles digit/letter display order).
+    The only added rule (bug 5) is that a plausible plate must contain BOTH a
+    letter and a digit; pure OCR garbage like "6466466" or "1211" is rejected
+    instead of being stored as a fake plate (which is what made saved numbers
+    not match their snapshot on the dashboard).
     """
     if not raw:
         return None
     raw = raw.strip().upper()
 
-    # Camera explicitly couldn't read the plate (and a bare "UNKNOWN" sentinel).
-    if raw in ("N/A", "NONE", "NULL", "", "UNKNOWN"):
+    # Camera explicitly couldn't read the plate
+    if raw in ("N/A", "NONE", "NULL", ""):
         return None
 
-    # Fold non-ASCII Unicode digits (e.g. Arabic-Indic ٠-٩, U+0660–0669) to ASCII
-    # BEFORE the [^A-Z0-9] cleanup — otherwise a plate whose digits the camera
-    # reported in Arabic-Indic numerals would be stripped to letters-only and
-    # wrongly rejected. (Python's str.isdigit() already treats them as digits.)
-    raw = "".join(
-        str(unicodedata.digit(c)) if (not c.isascii() and c.isdigit()) else c
-        for c in raw
-    )
-
-    # Plate "core" = letters and digits only (drop dashes, spaces, dots, …).
-    core = re.sub(r"[^A-Z0-9]", "", raw)
-    has_alpha = any(c.isalpha() for c in core)
-    has_digit = any(c.isdigit() for c in core)
-
-    # Reject OCR misreads: a real plate has BOTH letters and digits and a sane
-    # length (Saudi plates are ~5–7 alphanumerics; cap at 8 for slack). This
-    # drops all-digit garbage ("6466466", "1211") and concatenated misreads
-    # ("99999999HUD") rather than storing them as fake plates.
-    if not (3 <= len(core) <= 8) or not (has_alpha and has_digit):
-        logger.debug(f"[ANPR] Rejected implausible plate: {raw!r}")
+    # If the plate is EXACTLY "UNKNOWN", it means the camera failed.
+    # But if it is "UNKNOWN-X", it's a valid test plate.
+    if raw == "UNKNOWN":
         return None
 
-    # Canonical LETTERS-DIGITS, regardless of the order the camera reported.
-    m = re.match(r"^(\d+)([A-Z]+)$", core)   # digits then letters — e.g. "9444HUD"
-    if m:
-        return f"{m.group(2)}-{m.group(1)}"   # -> "HUD-9444"
-    m = re.match(r"^([A-Z]+)(\d+)$", core)   # letters then digits — e.g. "HUD9444"
-    if m:
-        return f"{m.group(1)}-{m.group(2)}"   # -> "HUD-9444"
+    # Bug 5: a real plate has BOTH letters and digits. Reject reads missing
+    # either (all-digit "6466466"/"1211", all-letter strings) so OCR garbage
+    # isn't stored. str.isdigit() is Unicode-aware, so Arabic-Indic numerals
+    # still count as digits. Storage of accepted plates is otherwise unchanged.
+    if not (any(c.isalpha() for c in raw) and any(c.isdigit() for c in raw)):
+        logger.debug(f"[ANPR] Rejected implausible plate (needs letters+digits): {raw!r}")
+        return None
 
-    # Interleaved / multi-segment (e.g. "9H4U4D") isn't a real plate layout —
-    # treat it as an OCR failure rather than storing a dash-less oddball.
-    logger.debug(f"[ANPR] Rejected non-plate layout: {raw!r}")
+    # Already normalised (e.g. "HUD-9444") — validate full format 3 letters + 4 digits
+    if "-" in raw:
+        # 1. Strict match for official International format (e.g., ABC-1234)
+        m = re.match(r"^([A-Z]{2,3})-(\d{3,4})$", raw)
+        if m:
+            return raw
+        # 2. Keep any other dashed read as-is (e.g. "9444-HUD", "TEST-001")
+        if len(raw) >= 3:
+            return raw
+        return None
+
+    # Saudi format: 1-4 digits then 2-3 letters  e.g. "9444HUD", "7HDU"
+    m = re.match(r"^(\d{1,4})([A-Z]{2,3})$", raw)
+    if m:
+        return f"{m.group(2)}-{m.group(1)}"
+
+    # Letters then digits  e.g. "HUD9444", "HDU7"
+    m = re.match(r"^([A-Z]{2,3})(\d{1,4})$", raw)
+    if m:
+        return f"{m.group(1)}-{m.group(2)}"
+
+    # If no specific pattern matches, return as is (lenient for testing/non-Saudi plates)
+    if len(raw) >= 3:
+        return raw
+
+    # Partial or unrecognized — reject
+    logger.debug(f"[ANPR] Rejected too short/invalid plate: {raw!r}")
     return None
 
 

--- a/app/services/event_parser.py
+++ b/app/services/event_parser.py
@@ -336,11 +336,12 @@ def _normalize_plate(raw: str) -> Optional[str]:
     separators, spacing, or case silently creates duplicate sessions / vehicle
     rows (the "registered twice" bug).
 
-    Canonical form: upper-cased, with a SINGLE ``-`` between the digit-run and
-    the letter-run, and the camera's original order PRESERVED — Saudi plates are
-    reported both ways and we keep what the camera sent ("1198-SHR" stays
-    digits-letters, "SHR-1198" stays letters-digits). So "9444HUD", "9444 HUD",
-    and "9444-HUD" all canonicalize to "9444-HUD".
+    Canonical form: upper-cased LETTERS-DIGITS with a SINGLE ``-`` between the
+    letter-run and the digit-run, regardless of the order the camera reported.
+    The DB convention is letters-first ("HUD-9444"); the frontend flips it to
+    digits-first ("9444-HUD") for display. Storing one consistent order is what
+    fixes the "registered twice" duplicates, so "9444HUD", "9444 HUD",
+    "9444-HUD", "HUD9444", and "HUD-9444" ALL canonicalize to "HUD-9444".
 
     Returns None for reads that are not plausibly a plate:
       - explicit failure tokens (N/A / NONE / NULL / UNKNOWN / empty)
@@ -381,13 +382,13 @@ def _normalize_plate(raw: str) -> Optional[str]:
         logger.debug(f"[ANPR] Rejected implausible plate: {raw!r}")
         return None
 
-    # Single dash between the two runs, preserving the reported order.
+    # Canonical LETTERS-DIGITS, regardless of the order the camera reported.
     m = re.match(r"^(\d+)([A-Z]+)$", core)   # digits then letters — e.g. "9444HUD"
     if m:
-        return f"{m.group(1)}-{m.group(2)}"
+        return f"{m.group(2)}-{m.group(1)}"   # -> "HUD-9444"
     m = re.match(r"^([A-Z]+)(\d+)$", core)   # letters then digits — e.g. "HUD9444"
     if m:
-        return f"{m.group(1)}-{m.group(2)}"
+        return f"{m.group(1)}-{m.group(2)}"   # -> "HUD-9444"
 
     # Interleaved / multi-segment (e.g. "9H4U4D") isn't a real plate layout —
     # treat it as an OCR failure rather than storing a dash-less oddball.

--- a/app/services/event_parser.py
+++ b/app/services/event_parser.py
@@ -327,53 +327,56 @@ def _parse_xml_event(raw_body: bytes, camera_ip: str) -> ParsedCameraEvent:
     )
 
 
-def _normalize_plate(raw: str) -> str:
+def _normalize_plate(raw: str) -> Optional[str]:
     """
-    Normalize Saudi plate format from camera output to display format.
-    Examples: "9444HUD" → "HUD-9444",  "7800ERD" → "ERD-7800"
-    Returns None for unknown/partial/invalid plates.
+    Canonicalize an ANPR plate read so the SAME physical plate always yields the
+    SAME string. Entry/exit dedup, open-session matching, and vehicle lookup all
+    compare ``plate_number`` by exact string equality, so any drift in
+    separators, spacing, or case silently creates duplicate sessions / vehicle
+    rows (the "registered twice" bug).
+
+    Canonical form: upper-cased, with a SINGLE ``-`` between the digit-run and
+    the letter-run, and the camera's original order PRESERVED — Saudi plates are
+    reported both ways and we keep what the camera sent ("1198-SHR" stays
+    digits-letters, "SHR-1198" stays letters-digits). So "9444HUD", "9444 HUD",
+    and "9444-HUD" all canonicalize to "9444-HUD".
+
+    Returns None for reads that are not plausibly a plate:
+      - explicit failure tokens (N/A / NONE / NULL / UNKNOWN / empty)
+      - reads missing EITHER a letter or a digit — a real plate always has both,
+        so OCR garbage like "6466466" or "1211" is rejected rather than stored
+        (storing it is what produced the "plate mismatch" records on the
+        dashboard, where the saved number didn't match the snapshot).
     """
     if not raw:
         return None
     raw = raw.strip().upper()
 
-    # Camera explicitly couldn't read the plate
-    if raw in ("N/A", "NONE", "NULL", ""):
-        return None
-        
-    # If the plate is EXACTLY "UNKNOWN", it means the camera failed.
-    # But if it is "UNKNOWN-X", it's a valid test plate.
-    if raw == "UNKNOWN":
+    # Camera explicitly couldn't read the plate (and a bare "UNKNOWN" sentinel).
+    if raw in ("N/A", "NONE", "NULL", "", "UNKNOWN"):
         return None
 
-    # Already normalised (e.g. "HUD-9444") — validate full format 3 letters + 4 digits
-    if "-" in raw:
-        # 1. Strict match for official International format (e.g., ABC-1234)
-        m = re.match(r"^([A-Z]{2,3})-(\d{3,4})$", raw)
-        if m:
-            return raw
-        # 2. Allow test plates with dashes (e.g., TEST-OK, UNKNOWN-X)
-        if len(raw) >= 3:
-            return raw
+    # Plate "core" = letters and digits only (drop dashes, spaces, dots, …).
+    core = re.sub(r"[^A-Z0-9]", "", raw)
+    has_alpha = any(c.isalpha() for c in core)
+    has_digit = any(c.isdigit() for c in core)
+
+    # Reject OCR misreads: a valid plate has BOTH letters and digits.
+    if not core or not (has_alpha and has_digit):
+        logger.debug(f"[ANPR] Rejected implausible plate (needs letters+digits): {raw!r}")
         return None
 
-    # Saudi format: 1-4 digits then 2-3 letters  e.g. "9444HUD", "7HDU"
-    m = re.match(r"^(\d{1,4})([A-Z]{2,3})$", raw)
+    # Single dash between the two runs, preserving the reported order.
+    m = re.match(r"^(\d+)([A-Z]+)$", core)   # digits then letters — e.g. "9444HUD"
     if m:
-        return f"{m.group(2)}-{m.group(1)}"
-
-    # Letters then digits  e.g. "HUD9444", "HDU7"
-    m = re.match(r"^([A-Z]{2,3})(\d{1,4})$", raw)
+        return f"{m.group(1)}-{m.group(2)}"
+    m = re.match(r"^([A-Z]+)(\d+)$", core)   # letters then digits — e.g. "HUD9444"
     if m:
         return f"{m.group(1)}-{m.group(2)}"
 
-    # If no specific pattern matches, return as is (lenient for testing/non-Saudi plates)
-    if len(raw) >= 3:
-        return raw
-
-    # Partial or unrecognized — reject
-    logger.debug(f"[ANPR] Rejected too short/invalid plate: {raw!r}")
-    return None
+    # Interleaved / multi-segment (rare) — can't split cleanly; return the
+    # cleaned core so the value is still deterministic across reads.
+    return core
 
 
 def _parse_json_event(raw_body: bytes, camera_ip: str) -> ParsedCameraEvent:

--- a/tests/test_event_parser.py
+++ b/tests/test_event_parser.py
@@ -177,12 +177,23 @@ class TestPlateNormalization:
         assert _normalize_plate(raw) == expected
 
     @pytest.mark.parametrize("raw", [
-        "6466466",   # all-digit OCR misread
-        "1211",      # all-digit OCR misread
-        "HUDABC",    # all-letter (no digit)
+        "6466466",     # all-digit OCR misread
+        "1211",        # all-digit OCR misread
+        "HUDABC",      # all-letter (no digit)
+        "99999999HUD", # concatenated / overlong misread
+        "9H4U4D",      # interleaved layout — not a real plate
         "UNKNOWN", "N/A", "NONE", "NULL", "", "  ",
     ])
     def test_rejects_implausible_reads(self, raw):
         from app.services.event_parser import _normalize_plate
         assert _normalize_plate(raw) is None
+
+    def test_arabic_indic_digits_folded_not_rejected(self):
+        """Digits the camera reports in Arabic-Indic numerals must fold to ASCII
+        and be accepted, not stripped to letters-only and rejected."""
+        from app.services.event_parser import _normalize_plate
+        # "HUD" + Arabic-Indic 9444 (U+0669 U+0664 U+0664 U+0664)
+        assert _normalize_plate("HUD٩٤٤٤") == "HUD-9444"
+        # digits-first Arabic-Indic 1198 + "SHR"
+        assert _normalize_plate("١١٩٨SHR") == "1198-SHR"
 

--- a/tests/test_event_parser.py
+++ b/tests/test_event_parser.py
@@ -157,20 +157,20 @@ class TestPlateNormalization:
     and malformed reads aren't stored as fake plates."""
 
     @pytest.mark.parametrize("raw,expected", [
-        # Same physical plate, varied separators/case → ONE canonical form
-        # (this is what fixes the "registered twice" duplicate sessions).
-        ("9444HUD", "9444-HUD"),
-        ("9444 HUD", "9444-HUD"),
-        ("9444-HUD", "9444-HUD"),
-        ("  9444-hud ", "9444-HUD"),
-        # Letter-first reads keep their order.
+        # Same physical plate, any order/separator/case → ONE canonical
+        # LETTERS-DIGITS form (this is what fixes the "registered twice"
+        # duplicate sessions). The frontend flips it to digits-first for display.
+        ("9444HUD", "HUD-9444"),
+        ("9444 HUD", "HUD-9444"),
+        ("9444-HUD", "HUD-9444"),
+        ("  9444-hud ", "HUD-9444"),
         ("HUD9444", "HUD-9444"),
         ("HUD-9444", "HUD-9444"),
-        # Already-canonical reads pass through unchanged (incl. production
-        # digits-letters format and existing test plates).
+        # Already letters-first reads pass through unchanged.
         ("ABC-1234", "ABC-1234"),
-        ("4918-AVD", "4918-AVD"),
         ("TEST-001", "TEST-001"),
+        # Digits-first reads are reordered to the stored letters-first form.
+        ("4918-AVD", "AVD-4918"),
     ])
     def test_canonicalizes_consistently(self, raw, expected):
         from app.services.event_parser import _normalize_plate
@@ -194,6 +194,6 @@ class TestPlateNormalization:
         from app.services.event_parser import _normalize_plate
         # "HUD" + Arabic-Indic 9444 (U+0669 U+0664 U+0664 U+0664)
         assert _normalize_plate("HUD٩٤٤٤") == "HUD-9444"
-        # digits-first Arabic-Indic 1198 + "SHR"
-        assert _normalize_plate("١١٩٨SHR") == "1198-SHR"
+        # digits-first Arabic-Indic 1198 + "SHR" -> stored letters-first
+        assert _normalize_plate("١١٩٨SHR") == "SHR-1198"
 

--- a/tests/test_event_parser.py
+++ b/tests/test_event_parser.py
@@ -152,48 +152,34 @@ class TestJSONEventParsing:
 
 
 class TestPlateNormalization:
-    """`_normalize_plate` canonicalizes reads + rejects OCR garbage so the same
-    physical plate always yields one string (dedup/matching rely on equality)
-    and malformed reads aren't stored as fake plates."""
+    """`_normalize_plate` stores plates exactly as before (the frontend handles
+    digit/letter display order) and only adds the bug-5 rule: a plausible plate
+    must contain BOTH a letter and a digit, so OCR garbage isn't stored."""
 
     @pytest.mark.parametrize("raw,expected", [
-        # Same physical plate, any order/separator/case → ONE canonical
-        # LETTERS-DIGITS form (this is what fixes the "registered twice"
-        # duplicate sessions). The frontend flips it to digits-first for display.
+        # No-separator reads get a dash inserted, as they always have.
         ("9444HUD", "HUD-9444"),
-        ("9444 HUD", "HUD-9444"),
-        ("9444-HUD", "HUD-9444"),
-        ("  9444-hud ", "HUD-9444"),
         ("HUD9444", "HUD-9444"),
+        # Dashed reads are kept AS STORED — order is not changed.
         ("HUD-9444", "HUD-9444"),
-        # Already letters-first reads pass through unchanged.
+        ("9444-HUD", "9444-HUD"),
+        ("4918-AVD", "4918-AVD"),
         ("ABC-1234", "ABC-1234"),
         ("TEST-001", "TEST-001"),
-        # Digits-first reads are reordered to the stored letters-first form.
-        ("4918-AVD", "AVD-4918"),
+        # Case is normalized to upper.
+        ("  9444-hud ", "9444-HUD"),
     ])
-    def test_canonicalizes_consistently(self, raw, expected):
+    def test_stores_plates_unchanged(self, raw, expected):
         from app.services.event_parser import _normalize_plate
         assert _normalize_plate(raw) == expected
 
     @pytest.mark.parametrize("raw", [
-        "6466466",     # all-digit OCR misread
-        "1211",        # all-digit OCR misread
-        "HUDABC",      # all-letter (no digit)
-        "99999999HUD", # concatenated / overlong misread
-        "9H4U4D",      # interleaved layout — not a real plate
+        "6466466",   # all-digit OCR misread
+        "1211",      # all-digit OCR misread
+        "HUDABC",    # all-letter (no digit)
         "UNKNOWN", "N/A", "NONE", "NULL", "", "  ",
     ])
     def test_rejects_implausible_reads(self, raw):
         from app.services.event_parser import _normalize_plate
         assert _normalize_plate(raw) is None
-
-    def test_arabic_indic_digits_folded_not_rejected(self):
-        """Digits the camera reports in Arabic-Indic numerals must fold to ASCII
-        and be accepted, not stripped to letters-only and rejected."""
-        from app.services.event_parser import _normalize_plate
-        # "HUD" + Arabic-Indic 9444 (U+0669 U+0664 U+0664 U+0664)
-        assert _normalize_plate("HUD٩٤٤٤") == "HUD-9444"
-        # digits-first Arabic-Indic 1198 + "SHR" -> stored letters-first
-        assert _normalize_plate("١١٩٨SHR") == "SHR-1198"
 

--- a/tests/test_event_parser.py
+++ b/tests/test_event_parser.py
@@ -150,3 +150,39 @@ class TestJSONEventParsing:
         assert event.event_type == "AccessControllerEvent"
         assert event.plate_number == "TEST-001"
 
+
+class TestPlateNormalization:
+    """`_normalize_plate` canonicalizes reads + rejects OCR garbage so the same
+    physical plate always yields one string (dedup/matching rely on equality)
+    and malformed reads aren't stored as fake plates."""
+
+    @pytest.mark.parametrize("raw,expected", [
+        # Same physical plate, varied separators/case → ONE canonical form
+        # (this is what fixes the "registered twice" duplicate sessions).
+        ("9444HUD", "9444-HUD"),
+        ("9444 HUD", "9444-HUD"),
+        ("9444-HUD", "9444-HUD"),
+        ("  9444-hud ", "9444-HUD"),
+        # Letter-first reads keep their order.
+        ("HUD9444", "HUD-9444"),
+        ("HUD-9444", "HUD-9444"),
+        # Already-canonical reads pass through unchanged (incl. production
+        # digits-letters format and existing test plates).
+        ("ABC-1234", "ABC-1234"),
+        ("4918-AVD", "4918-AVD"),
+        ("TEST-001", "TEST-001"),
+    ])
+    def test_canonicalizes_consistently(self, raw, expected):
+        from app.services.event_parser import _normalize_plate
+        assert _normalize_plate(raw) == expected
+
+    @pytest.mark.parametrize("raw", [
+        "6466466",   # all-digit OCR misread
+        "1211",      # all-digit OCR misread
+        "HUDABC",    # all-letter (no digit)
+        "UNKNOWN", "N/A", "NONE", "NULL", "", "  ",
+    ])
+    def test_rejects_implausible_reads(self, raw):
+        from app.services.event_parser import _normalize_plate
+        assert _normalize_plate(raw) is None
+


### PR DESCRIPTION
Backend fix for the **Parking Management V0 bug sheet (1-6-2026)** — PMS-AI (System 1) side.

## Net change
`_normalize_plate()` now **rejects implausible OCR reads** — a plausible plate must contain **both a letter and a digit**, so all-digit garbage like `6466466` / `1211` is dropped (returns `None`) instead of being stored as a fake plate. **Stored format of real plates is unchanged** — the frontend handles digit/letter display order, and the gateway search is order-insensitive.

This addresses the **"Mismatch plate no"** bug to the extent backend can: it stops garbage reads from being persisted. A genuine wrong-character misread of a real plate is camera/ANPR hardware and cannot be fixed in code.

## Relationship to "registered twice"
Garbage rejection plus the existing dedup guards (30s window, open-session check, anti-bounce) remain. Stronger guards (plate canonicalization / a DB unique index) were intentionally **not** included per product decision (keep stored format as-is, no migration). Can be revisited with compare-time dedup if duplicates persist.

## Commit history note
The intermediate commits explored canonicalizing the plate format; that was reverted per review + product decision. The **net diff vs `develop`** is just: the bug-5 garbage-rejection guard + a `TestPlateNormalization` test class. (Squash on merge if you prefer a single commit.)

## Verification
- Full test suite: **76 passed** (added `TestPlateNormalization` covering accepted formats unchanged + garbage rejected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)