### PR TITLE
feat(anpr): always forward identity image to VA + reliable delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -155,6 +155,14 @@ NODEBACK_SERVICE_KEY=damanat-internal-service-key-2026
 # Leave empty to disable PMS forwarding
 PMS_API_URL=http://localhost:8000
 
+# Reliability for the forward above: on a transient failure the undelivered
+# payload is spooled to disk and re-POSTed from a background task (every
+# DRAIN_INTERVAL) until VA acks, so an image is not lost when VA is briefly
+# unreachable. Payloads older than SPOOL_MAX_AGE are dropped.
+PMS_FORWARD_SPOOL_DIR=./pms_forward_spool
+PMS_FORWARD_DRAIN_INTERVAL_SECONDS=15.0
+PMS_FORWARD_SPOOL_MAX_AGE_SECONDS=3600.0
+
 # ── Camera inventory loaded from the DB `cameras` table ──────────────────────
 # At startup the camera inventory (id, ip, username, password, name) is read
 # from the shared DB instead of the CAM_XX_* vars above (those are kept as a

--- a/app/config.py
+++ b/app/config.py
@@ -370,6 +370,17 @@ class Settings(BaseSettings):
     # entry_exit_service.py:73-103.
     ENTRY_ANTIBOUNCE_SECONDS: int = 30
 
+    # ── PMS/VA forward reliability (port 8000) ───────────────────────────
+    # notify_pms_anpr forwards ANPR identity images to the VA core backend. A
+    # single fire-and-forget POST silently loses the image whenever VA is
+    # momentarily unreachable, so on a transient failure the payload is spooled
+    # to disk and re-POSTed from a background task (every DRAIN_INTERVAL) until
+    # VA acks. The drain interval is the retry cadence — the live forward stays a
+    # single attempt so it never adds latency to the exit webhook / burst flusher.
+    PMS_FORWARD_SPOOL_DIR: str = "./pms_forward_spool"
+    PMS_FORWARD_DRAIN_INTERVAL_SECONDS: float = 15.0   # background re-POST cadence
+    PMS_FORWARD_SPOOL_MAX_AGE_SECONDS: float = 3600.0  # drop spooled payloads older than this
+
     # ── Snapshot fetch auth fallback ─────────────────────────────────────
     # Default empty = Digest only (Hikvision standard). Set to "basic" to
     # try Basic auth as a second pass when Digest gets 401/403. Used to

--- a/app/main.py
+++ b/app/main.py
@@ -138,6 +138,26 @@ async def startup():
     app.state.entry_burst_flusher = asyncio.create_task(_entry_burst_flusher_loop())
     logger.info("🧹 Entry-burst flusher task started")
 
+    # Background drain for undelivered ANPR forwards to the VA backend. When VA
+    # is briefly unreachable, notify_pms_anpr spools the payload to disk instead
+    # of dropping it; this task re-POSTs the spool until VA acks.
+    app.state.pms_forward_drainer = asyncio.create_task(_pms_forward_drainer_loop())
+    logger.info("📤 PMS/VA forward-spool drainer task started")
+
+
+async def _pms_forward_drainer_loop():
+    """Periodically re-POST any spooled ANPR forwards to the VA backend so an
+    image is not lost when VA was down at forward time."""
+    from app.utils.core_backend_client import drain_pms_forward_spool
+    while True:
+        try:
+            await asyncio.sleep(float(settings.PMS_FORWARD_DRAIN_INTERVAL_SECONDS))
+            await drain_pms_forward_spool()
+        except asyncio.CancelledError:
+            break
+        except Exception as e:
+            logger.error(f"[PMS] Forward-spool drain tick failed: {e}", exc_info=True)
+
 
 async def _entry_burst_flusher_loop():
     """Every ~0.5s flush any confirmed entry burst that has settled (idle window)
@@ -160,10 +180,11 @@ async def _entry_burst_flusher_loop():
 @app.on_event("shutdown")
 async def shutdown():
     logger.info("🛑 Damanat Backend shutting down...")
-    task = getattr(app.state, "entry_burst_flusher", None)
-    if task is not None:
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
+    for attr in ("entry_burst_flusher", "pms_forward_drainer"):
+        task = getattr(app.state, attr, None)
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass

--- a/app/services/entry_exit_service.py
+++ b/app/services/entry_exit_service.py
@@ -364,6 +364,13 @@ async def _flush_entry_burst(db: Session, buf: dict) -> None:
         f"discarded={discarded}"
     )
 
+    # dedup / anti-bounce suppress only the PMS-side occupancy record (the
+    # EntryExitLog row, the open session, the alert). They must NOT suppress the
+    # forward of the identity image to VA (port 8000): VA has its own dedup and
+    # needs the image to (re)build the car's ReID identity + on-disk folder.
+    suppress_occupancy = False
+    suppress_reason = ""
+
     # Deduplication: same plate already logged as an entry in the last 30s.
     dedup_window = event_time - timedelta(seconds=30)
     recent = (
@@ -376,13 +383,17 @@ async def _flush_entry_burst(db: Session, buf: dict) -> None:
         .first()
     )
     if recent:
-        logger.debug(f"[UC1] Duplicate entry suppressed for plate={plate}")
-        return
+        suppress_occupancy = True
+        suppress_reason = "duplicate"
+        logger.debug(
+            f"[UC1] Duplicate entry — occupancy suppressed for plate={plate} "
+            f"(VA still notified)"
+        )
 
     # Anti-bounce: an entry whose plate just exited within the window is the
     # entry camera catching a car driving away from the exit gate — suppress.
     antibounce_s = settings.ENTRY_ANTIBOUNCE_SECONDS
-    if antibounce_s > 0:
+    if not suppress_occupancy and antibounce_s > 0:
         recent_exit_window = event_time - timedelta(seconds=antibounce_s)
         recent_exit = (
             db.query(EntryExitLog)
@@ -396,19 +407,21 @@ async def _flush_entry_burst(db: Session, buf: dict) -> None:
         )
         if recent_exit:
             gap_s = (event_time - recent_exit.event_time).total_seconds()
+            suppress_occupancy = True
+            suppress_reason = "anti-bounce"
             logger.info(
-                "[UC1] Anti-bounce: suppressed entry for plate=%s "
-                "(last exit %.1fs ago, window=%ds)",
+                "[UC1] Anti-bounce: occupancy suppressed for plate=%s "
+                "(last exit %.1fs ago, window=%ds) — VA still notified",
                 plate, gap_s, antibounce_s,
             )
-            return
 
     # Register this entry in the recent-entries cache BEFORE any network I/O, so a
     # CAM-03 crossing that fires during the forwards below (the normal ordering)
-    # can already attach its image. We're past dedup/anti-bounce here, so the entry
-    # is committed-to. sent_sources seeds with the snapshots collected so far, so a
-    # CAM-03 already in confirm_snapshots is not double-sent, while a CAM-03 that
-    # arrives mid-flush finds this entry instead of falling through to an older car.
+    # can already attach its image. Registered even when occupancy is suppressed,
+    # so a late CAM-03 B-entry still reaches VA (the primary ReID reference).
+    # sent_sources seeds with the snapshots collected so far, so a CAM-03 already
+    # in confirm_snapshots is not double-sent, while a CAM-03 that arrives
+    # mid-flush finds this entry instead of falling through to an older car.
     confirm_snapshots = buf.get("confirm_snapshots") or {}
     async with _bursts_lock:
         match_window = settings.ENTRY_CONFIRM_MATCH_SECONDS
@@ -432,35 +445,44 @@ async def _flush_entry_burst(db: Session, buf: dict) -> None:
     except Exception as e:
         logger.warning(f"[UC1] PMS API forwarding failed for plate={plate}: {e}")
 
-    # UC4: resolve the vehicle for the WINNING plate only — so the only vehicles
-    # row this entry creates is for the final, correct plate.
-    vehicle = vehicle_service.ensure_unregistered_vehicle(db, plate)
-    vehicle_type = vehicle.vehicle_type if vehicle else "unknown"
+    # PMS occupancy record — the EntryExitLog row + open parking session. Skipped
+    # when dedup/anti-bounce suppressed this entry; VA was already notified above.
+    vehicle = None
+    if not suppress_occupancy:
+        # UC4: resolve the vehicle for the WINNING plate only — so the only
+        # vehicles row this entry creates is for the final, correct plate.
+        vehicle = vehicle_service.ensure_unregistered_vehicle(db, plate)
+        vehicle_type = vehicle.vehicle_type if vehicle else "unknown"
 
-    log_entry = EntryExitLog(
-        plate_number=plate,
-        vehicle_id=vehicle.id if vehicle else None,
-        vehicle_type=vehicle_type,
-        gate="entry",
-        camera_id=camera_id,
-        event_time=event_time,
-        snapshot_path=snapshot_path,
-        plate_confidence=confidence,
-        created_at=facility_now_naive(),
-    )
-    db.add(log_entry)
-    parking_session_service.open_session(
-        db,
-        plate_number=plate,
-        event_time=event_time,
-        camera_id=camera_id,
-        snapshot_path=snapshot_path,
-        vehicle=vehicle,
-    )
-    logger.info(
-        f"[UC1] Entry CONFIRMED (burst flush): plate={plate} "
-        f"source={buf.get('confirm_source') or 'idle/boundary'}"
-    )
+        log_entry = EntryExitLog(
+            plate_number=plate,
+            vehicle_id=vehicle.id if vehicle else None,
+            vehicle_type=vehicle_type,
+            gate="entry",
+            camera_id=camera_id,
+            event_time=event_time,
+            snapshot_path=snapshot_path,
+            plate_confidence=confidence,
+            created_at=facility_now_naive(),
+        )
+        db.add(log_entry)
+        parking_session_service.open_session(
+            db,
+            plate_number=plate,
+            event_time=event_time,
+            camera_id=camera_id,
+            snapshot_path=snapshot_path,
+            vehicle=vehicle,
+        )
+        logger.info(
+            f"[UC1] Entry CONFIRMED (burst flush): plate={plate} "
+            f"source={buf.get('confirm_source') or 'idle/boundary'}"
+        )
+    else:
+        logger.info(
+            f"[UC1] Entry occupancy suppressed ({suppress_reason}) for "
+            f"plate={plate}; VA identity image forwarded"
+        )
 
     # Forward every confirmation snapshot collected so far (CAM-23, and CAM-03 if
     # it already fired) — each under its own PMS direction marker, after the gate
@@ -470,8 +492,11 @@ async def _flush_entry_burst(db: Session, buf: dict) -> None:
         if image:
             await _forward_confirm_snapshot(plate, src, image)
 
-    # UC4 alert/notification.
-    if vehicle and vehicle.is_registered:
+    # UC4 alert/notification — only when we actually recorded the entry above.
+    # A dedup/anti-bounce-suppressed entry must not raise a fresh gate alert.
+    if suppress_occupancy:
+        pass
+    elif vehicle and vehicle.is_registered:
         from app.services.alert_service import broadcast_event
         await broadcast_event(
             is_alert=False,

--- a/app/utils/core_backend_client.py
+++ b/app/utils/core_backend_client.py
@@ -5,6 +5,10 @@ Auth: static X-Service-Key header (no JWT).
 Fire-and-forget safe: all failures are logged and never block camera event processing.
 """
 
+import base64
+import json
+import os
+import uuid
 from datetime import datetime
 from typing import Optional
 import httpx
@@ -143,6 +147,79 @@ async def notify_exit(
 
 # ── PMS Tracking API (plate forwarding) ────────────────────────────────
 
+async def _deliver_anpr_payload(body: dict) -> str:
+    """POST one ANPR payload to the VA tracking API, in a single attempt.
+
+    Returns one of:
+      "ok"    — VA acked (HTTP 200/201).
+      "drop"  — VA rejected it permanently (HTTP 4xx); never retry, discard.
+      "retry" — transient failure (connect error / timeout / 5xx); try later.
+
+    Never raises. Deliberately ONE attempt with no inline retry loop: this call
+    is awaited on the exit webhook (handle_anpr_event) and inside the entry-burst
+    flusher, so an inline retry+backoff would add multi-second latency there when
+    VA is down. The background spool drain provides the retry cadence instead."""
+    url = f"{settings.PMS_API_URL}/api/anpr/event"
+    plate = body.get("plate")
+    direction = body.get("direction")
+    has_img = bool(body.get("image_base64"))
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.post(
+                url, json=body, headers={"Content-Type": "application/json"}
+            )
+    except httpx.ConnectError:
+        logger.warning(f"[PMS] Unreachable — could not forward plate={plate}")
+        return "retry"
+    except Exception as e:
+        logger.warning(f"[PMS] Forward failed for plate={plate}: {e}")
+        return "retry"
+
+    if resp.status_code in (200, 201):
+        logger.info(
+            f"[PMS] Plate forwarded: {plate} ({direction}) "
+            f"image={'yes' if has_img else 'no'}"
+        )
+        return "ok"
+    if 400 <= resp.status_code < 500:
+        # Client error — the payload itself is bad; retrying can never succeed,
+        # so drop it rather than spooling a poison item that wedges the drain.
+        logger.warning(
+            f"[PMS] VA rejected plate={plate} ({direction}) HTTP "
+            f"{resp.status_code}: {resp.text[:200]} — dropping (not retryable)"
+        )
+        return "drop"
+    logger.warning(
+        f"[PMS] POST /api/anpr/event -> HTTP {resp.status_code}: "
+        f"{resp.text[:200]} — will retry"
+    )
+    return "retry"
+
+
+def _spool_payload(body: dict) -> None:
+    """Persist an undelivered ANPR forward to disk so a background drain can
+    re-POST it once VA is reachable again — instead of losing the image."""
+    try:
+        d = settings.PMS_FORWARD_SPOOL_DIR
+        os.makedirs(d, exist_ok=True)
+        record = dict(body)
+        record["_spooled_at"] = datetime.now().isoformat()
+        fname = (
+            f"anpr_{datetime.now().strftime('%Y%m%d_%H%M%S_%f')}_"
+            f"{uuid.uuid4().hex[:8]}.json"
+        )
+        tmp = os.path.join(d, fname + ".tmp")
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(record, fh)
+        os.replace(tmp, os.path.join(d, fname))
+        logger.warning(
+            f"[PMS] Spooled undelivered plate={body.get('plate')} "
+            f"({body.get('direction')}) for later retry"
+        )
+    except Exception as e:
+        logger.warning(f"[PMS] Failed to spool plate={body.get('plate')}: {e}")
+
+
 async def notify_pms_anpr(
     plate: str,
     direction: str,
@@ -151,13 +228,13 @@ async def notify_pms_anpr(
     """
     Forward ANPR detection to the PMS tracking API.
     Sends plate + direction + base64-encoded snapshot image.
-    Fire-and-forget: failures are logged but never block camera event processing.
+    One inline attempt; on a transient failure the payload is spooled to disk and
+    re-POSTed by the background drain, so the image is not lost when VA is briefly
+    unreachable. Never blocks camera event processing (all failures are logged /
+    spooled, never raised).
     """
     if not settings.PMS_API_URL:
         return
-
-    import base64
-    import os
 
     image_base64 = ""
 
@@ -188,16 +265,79 @@ async def notify_pms_anpr(
         "image_base64": image_base64,
     }
 
-    url = f"{settings.PMS_API_URL}/api/anpr/event"
-    try:
-        async with httpx.AsyncClient(timeout=10) as client:
-            resp = await client.post(url, json=body, headers={"Content-Type": "application/json"})
-            if resp.status_code in (200, 201):
-                logger.info(f"[PMS] Plate forwarded: {plate} ({direction}) image={'yes' if image_base64 else 'no'}")
-            else:
-                logger.warning(f"[PMS] POST /api/anpr/event -> HTTP {resp.status_code}: {resp.text[:200]}")
-    except httpx.ConnectError:
-        logger.warning(f"[PMS] Unreachable — could not forward plate={plate}")
-    except Exception as e:
-        logger.warning(f"[PMS] Forward failed for plate={plate}: {e}")
+    status = await _deliver_anpr_payload(body)
+    if status == "retry":
+        # Transient — keep the image for the background drain to redeliver.
+        _spool_payload(body)
+    # "ok" → delivered; "drop" → VA rejected it permanently, discard (no spool).
+
+
+async def drain_pms_forward_spool() -> None:
+    """Re-POST spooled ANPR forwards to VA; delete each on success.
+
+    Runs periodically from the background drain task. Processes oldest-first
+    (spool filenames are timestamped). Delivered ("ok") and permanently-rejected
+    ("drop", HTTP 4xx) payloads are removed and the drain moves on — a bad
+    payload never wedges the queue behind it. Only a transient failure ("retry",
+    VA still down) stops the pass so ordering is preserved and VA isn't hammered.
+    Payloads older than ``PMS_FORWARD_SPOOL_MAX_AGE_SECONDS`` are dropped. No-op
+    when forwarding is disabled or the spool dir is empty."""
+    if not settings.PMS_API_URL:
+        return
+    d = settings.PMS_FORWARD_SPOOL_DIR
+    if not os.path.isdir(d):
+        return
+    now = datetime.now()
+    max_age = float(settings.PMS_FORWARD_SPOOL_MAX_AGE_SECONDS)
+    for fname in sorted(os.listdir(d)):
+        if not fname.endswith(".json"):
+            continue
+        fpath = os.path.join(d, fname)
+        try:
+            with open(fpath, "r", encoding="utf-8") as fh:
+                record = json.load(fh)
+        except Exception:
+            # Corrupt/partial file — remove so it doesn't wedge the drain.
+            try:
+                os.remove(fpath)
+            except OSError:
+                pass
+            continue
+
+        # Drop stale payloads. Parse age and expiry independently of the delete
+        # so a bad timestamp or a failed remove still skips (never re-POSTs) the
+        # stale item rather than falling through to deliver it.
+        spooled_at = record.pop("_spooled_at", None)
+        age = None
+        if spooled_at:
+            try:
+                age = (now - datetime.fromisoformat(spooled_at)).total_seconds()
+            except Exception:
+                age = None
+        if age is not None and age > max_age:
+            try:
+                os.remove(fpath)
+                logger.warning(
+                    f"[PMS] Dropped stale spooled plate={record.get('plate')} "
+                    f"(age {age:.0f}s > {max_age:.0f}s)"
+                )
+            except OSError:
+                pass
+            continue
+
+        body = {
+            "plate": record.get("plate"),
+            "direction": record.get("direction"),
+            "image_base64": record.get("image_base64", ""),
+        }
+        status = await _deliver_anpr_payload(body)
+        if status in ("ok", "drop"):
+            # Delivered or permanently rejected — remove and keep draining.
+            try:
+                os.remove(fpath)
+            except OSError:
+                pass
+            continue
+        # "retry" — VA still unreachable; leave the rest for the next interval.
+        break
 

--- a/tests/test_entry_suppression_forward.py
+++ b/tests/test_entry_suppression_forward.py
@@ -1,0 +1,181 @@
+# tests/test_entry_suppression_forward.py
+"""B1 — decouple the VA identity forward from PMS occupancy suppression.
+
+dedup and anti-bounce must suppress ONLY the PMS-side occupancy record (the
+EntryExitLog row, the open session, the UC4 alert). They must NOT suppress the
+forward of the identity image to VA (port 8000): VA has its own dedup and needs
+the image to (re)build the car's ReID identity + on-disk folder. This is the
+root cause of DJS-7842 getting no folder — its anti-bounce-suppressed entry
+never reached VA.
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+from datetime import datetime, timedelta
+
+from app.services.entry_exit_service import (
+    handle_anpr_event,
+    flush_due_entry_bursts,
+    _entry_bursts,
+    _pending_crossings,
+    _recent_entries,
+)
+from app.services.event_parser import ParsedCameraEvent
+from app.config import facility_now_naive
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def make_anpr_event(plate="ABC-1234", trigger_time=None, pic_num=1):
+    return ParsedCameraEvent(
+        camera_id="CAM-ENTRY",
+        device_serial="TEST-ANPR",
+        channel_id=1,
+        event_type="AccessControllerEvent",
+        detection_target="vehicle",
+        region_id="entry",
+        channel_name="Test ANPR",
+        trigger_time=trigger_time,
+        raw_xml="{}",
+        plate_number=plate,
+        gate="entry",
+        pic_num=pic_num,
+        plate_confidence=90,
+    )
+
+
+def make_db(first_side_effect=None):
+    db = MagicMock()
+    q = db.query.return_value
+    q.filter.return_value = q
+    q.order_by.return_value = q
+    if first_side_effect is not None:
+        q.first.side_effect = first_side_effect
+    else:
+        q.first.return_value = None
+    return db
+
+
+def configure_settings(mock_settings, *, antibounce: int):
+    mock_settings.USE_CAM03_ENTRY_CONFIRMATION = False  # idle window alone flushes
+    mock_settings.CAMERAS = {"CAM-ENTRY": {"gate": "entry"}, "CAM-EXIT": {"gate": "exit"}}
+    mock_settings.ENTRY_ANTIBOUNCE_SECONDS = antibounce
+    mock_settings.ANPR_BURST_WINDOW_SECONDS = 2.5
+    mock_settings.ANPR_BURST_MAX_SECONDS = 8.0
+    mock_settings.ENTRY_CONFIRM_DIRECTIONS = "CAM-23:ramp-entry,CAM-03:B-entry"
+    mock_settings.ENTRY_CONFIRM_MATCH_SECONDS = 30.0
+
+
+def _force_idle():
+    old = facility_now_naive() - timedelta(seconds=999)
+    for b in _entry_bursts.values():
+        b["last_read_at"] = old
+
+
+def _recent_exit_row(event_time):
+    row = MagicMock()
+    row.event_time = event_time
+    return row
+
+
+class TestSuppressionStillForwards:
+    def setup_method(self):
+        _entry_bursts.clear()
+        _pending_crossings.clear()
+        _recent_entries.clear()
+
+    # ── Anti-bounce: DB suppressed, VA still notified ──────────────────────
+    @pytest.mark.asyncio
+    @patch("app.services.entry_exit_service.core_backend_client.notify_pms_anpr", new_callable=AsyncMock)
+    @patch("app.services.entry_exit_service.settings")
+    @patch("app.services.entry_exit_service.create_alert", new_callable=AsyncMock)
+    @patch("app.services.entry_exit_service.parking_session_service.open_session")
+    @patch("app.services.entry_exit_service.vehicle_service")
+    async def test_antibounce_suppresses_db_but_forwards_to_va(
+        self, mock_vs, mock_open, mock_alert, mock_settings, mock_pms
+    ):
+        configure_settings(mock_settings, antibounce=30)
+        t = datetime(2026, 3, 8, 12, 0, 0)  # naive facility-local
+        db = make_db(first_side_effect=[
+            None,                                   # dedup: no recent entry
+            _recent_exit_row(t - timedelta(seconds=10)),  # anti-bounce: exit 10s ago
+        ])
+
+        await handle_anpr_event(make_anpr_event(plate="DJS-7842", trigger_time=t), db)
+        _force_idle()
+        await flush_due_entry_bursts(db)
+
+        # Occupancy suppressed: no EntryExitLog row, no session, no vehicle row.
+        db.add.assert_not_called()
+        mock_open.assert_not_called()
+        mock_vs.ensure_unregistered_vehicle.assert_not_called()
+
+        # But VA WAS notified with the entry identity image.
+        entry_pushes = [c for c in mock_pms.await_args_list if c.args[1] == "entry"]
+        assert len(entry_pushes) == 1
+        assert entry_pushes[0].args[0] == "DJS-7842"
+
+    # ── Dedup: DB suppressed, VA still notified ────────────────────────────
+    @pytest.mark.asyncio
+    @patch("app.services.entry_exit_service.core_backend_client.notify_pms_anpr", new_callable=AsyncMock)
+    @patch("app.services.entry_exit_service.settings")
+    @patch("app.services.entry_exit_service.create_alert", new_callable=AsyncMock)
+    @patch("app.services.entry_exit_service.parking_session_service.open_session")
+    @patch("app.services.entry_exit_service.vehicle_service")
+    async def test_dedup_suppresses_db_but_forwards_to_va(
+        self, mock_vs, mock_open, mock_alert, mock_settings, mock_pms
+    ):
+        configure_settings(mock_settings, antibounce=0)
+        t = datetime(2026, 3, 8, 12, 0, 0)
+        db = make_db(first_side_effect=[
+            _recent_exit_row(t - timedelta(seconds=5)),  # dedup: a recent entry exists
+            None,
+        ])
+
+        await handle_anpr_event(make_anpr_event(plate="LLJ-9005", trigger_time=t), db)
+        _force_idle()
+        await flush_due_entry_bursts(db)
+
+        db.add.assert_not_called()
+        mock_open.assert_not_called()
+        mock_vs.ensure_unregistered_vehicle.assert_not_called()
+
+        entry_pushes = [c for c in mock_pms.await_args_list if c.args[1] == "entry"]
+        assert len(entry_pushes) == 1
+        assert entry_pushes[0].args[0] == "LLJ-9005"
+
+    # ── Control: a normal entry still writes the DB AND forwards ───────────
+    @pytest.mark.asyncio
+    @patch("app.services.entry_exit_service.core_backend_client.notify_pms_anpr", new_callable=AsyncMock)
+    @patch("app.services.entry_exit_service.settings")
+    @patch("app.services.entry_exit_service.create_alert", new_callable=AsyncMock)
+    @patch("app.services.entry_exit_service.parking_session_service.open_session")
+    @patch("app.services.entry_exit_service.vehicle_service")
+    async def test_normal_entry_still_writes_and_forwards(
+        self, mock_vs, mock_open, mock_alert, mock_settings, mock_pms
+    ):
+        configure_settings(mock_settings, antibounce=30)
+        v = MagicMock()
+        v.id = 42
+        v.vehicle_type = "unknown"
+        v.is_registered = False
+        mock_vs.ensure_unregistered_vehicle.return_value = v
+        t = datetime(2026, 3, 8, 12, 0, 0)
+        db = make_db(first_side_effect=[None, None])  # no dedup, no recent exit
+
+        await handle_anpr_event(make_anpr_event(plate="OKAY-0001", trigger_time=t), db)
+        _force_idle()
+        await flush_due_entry_bursts(db)
+
+        # Occupancy recorded.
+        db.add.assert_called_once()
+        assert db.add.call_args[0][0].plate_number == "OKAY-0001"
+        mock_open.assert_called_once()
+        # And VA notified.
+        entry_pushes = [c for c in mock_pms.await_args_list if c.args[1] == "entry"]
+        assert len(entry_pushes) == 1
+        assert entry_pushes[0].args[0] == "OKAY-0001"

--- a/tests/test_pms_forward_reliability.py
+++ b/tests/test_pms_forward_reliability.py
@@ -1,0 +1,215 @@
+# tests/test_pms_forward_reliability.py
+"""B2 — reliable VA delivery: single-attempt tri-state + durable spool + drain.
+
+The old forward was fire-and-forget with no retry, so whenever VA was briefly
+unreachable the identity image was lost permanently (the "some images didn't
+arrive to VA" symptom). The new path:
+
+  * ``_deliver_anpr_payload`` does ONE attempt and returns "ok" / "drop" (4xx,
+    never retryable) / "retry" (connect error / 5xx) — no inline retry loop, so
+    the webhook that awaits it never blocks for seconds when VA is down.
+  * ``notify_pms_anpr`` spools the payload to disk on "retry", discards on
+    "drop", nothing on "ok".
+  * ``drain_pms_forward_spool`` re-POSTs oldest-first, removing on "ok"/"drop"
+    (a bad payload never wedges the queue) and stopping only on "retry"; stale
+    payloads are dropped without delivery.
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import json
+import tempfile
+from datetime import datetime, timedelta
+
+import httpx
+import pytest
+from unittest.mock import patch
+
+import app.utils.core_backend_client as cbc
+
+
+# ── Fake httpx client ─────────────────────────────────────────────────────────
+
+class _FakeResp:
+    def __init__(self, status, text=""):
+        self.status_code = status
+        self.text = text
+
+
+class _FakeClient:
+    """One-shot async context-manager client: its single ``post`` returns the
+    configured response or raises the configured exception."""
+
+    def __init__(self, outcome):
+        self._outcome = outcome
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, *args, **kwargs):
+        if isinstance(self._outcome, Exception):
+            raise self._outcome
+        return self._outcome
+
+
+def _client_factory(*outcomes):
+    """Return an ``httpx.AsyncClient`` replacement that yields one _FakeClient
+    per call, walking through ``outcomes`` in order."""
+    it = iter(outcomes)
+
+    def factory(*args, **kwargs):
+        return _FakeClient(next(it))
+
+    return factory
+
+
+def _settings(tmp, *, max_age=3600.0, api="http://va:8000"):
+    s = type("S", (), {})()
+    s.PMS_API_URL = api
+    s.PMS_FORWARD_SPOOL_DIR = tmp
+    s.PMS_FORWARD_SPOOL_MAX_AGE_SECONDS = max_age
+    return s
+
+
+def _spool_files(d):
+    return [f for f in os.listdir(d) if f.endswith(".json")]
+
+
+# ── _deliver_anpr_payload tri-state ───────────────────────────────────────────
+
+class TestDeliverTriState:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status,expected", [(200, "ok"), (201, "ok")])
+    async def test_2xx_is_ok(self, status, expected):
+        with patch.object(cbc, "settings", _settings("/x")), \
+             patch.object(cbc.httpx, "AsyncClient", _client_factory(_FakeResp(status))):
+            assert await cbc._deliver_anpr_payload({"plate": "A"}) == expected
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [400, 404, 422])
+    async def test_4xx_is_drop(self, status):
+        with patch.object(cbc, "settings", _settings("/x")), \
+             patch.object(cbc.httpx, "AsyncClient", _client_factory(_FakeResp(status, "bad"))):
+            assert await cbc._deliver_anpr_payload({"plate": "A"}) == "drop"
+
+    @pytest.mark.asyncio
+    async def test_5xx_is_retry(self):
+        with patch.object(cbc, "settings", _settings("/x")), \
+             patch.object(cbc.httpx, "AsyncClient", _client_factory(_FakeResp(503, "down"))):
+            assert await cbc._deliver_anpr_payload({"plate": "A"}) == "retry"
+
+    @pytest.mark.asyncio
+    async def test_connect_error_is_retry(self):
+        with patch.object(cbc, "settings", _settings("/x")), \
+             patch.object(cbc.httpx, "AsyncClient",
+                          _client_factory(httpx.ConnectError("refused"))):
+            assert await cbc._deliver_anpr_payload({"plate": "A"}) == "retry"
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_is_retry(self):
+        with patch.object(cbc, "settings", _settings("/x")), \
+             patch.object(cbc.httpx, "AsyncClient",
+                          _client_factory(RuntimeError("boom"))):
+            assert await cbc._deliver_anpr_payload({"plate": "A"}) == "retry"
+
+
+# ── notify_pms_anpr: spool on retry, discard on drop, nothing on ok ───────────
+
+class TestNotifySpoolPolicy:
+    @pytest.mark.asyncio
+    async def test_retry_spools_the_payload(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(cbc, "settings", _settings(tmp)), \
+                 patch.object(cbc.httpx, "AsyncClient",
+                              _client_factory(httpx.ConnectError("down"))):
+                await cbc.notify_pms_anpr("DJS-7842", "entry", image_path=None)
+            files = _spool_files(tmp)
+            assert len(files) == 1
+            body = json.load(open(os.path.join(tmp, files[0]), encoding="utf-8"))
+            assert body["plate"] == "DJS-7842"
+            assert body["direction"] == "entry"
+            assert "_spooled_at" in body
+
+    @pytest.mark.asyncio
+    async def test_drop_does_not_spool(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(cbc, "settings", _settings(tmp)), \
+                 patch.object(cbc.httpx, "AsyncClient",
+                              _client_factory(_FakeResp(400, "bad"))):
+                await cbc.notify_pms_anpr("DJS-7842", "entry", image_path=None)
+            assert _spool_files(tmp) == []
+
+    @pytest.mark.asyncio
+    async def test_ok_does_not_spool(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(cbc, "settings", _settings(tmp)), \
+                 patch.object(cbc.httpx, "AsyncClient",
+                              _client_factory(_FakeResp(200))):
+                await cbc.notify_pms_anpr("DJS-7842", "entry", image_path=None)
+            assert _spool_files(tmp) == []
+
+
+# ── drain_pms_forward_spool ───────────────────────────────────────────────────
+
+def _write_spool(d, plate, spooled_at=None):
+    os.makedirs(d, exist_ok=True)
+    rec = {"plate": plate, "direction": "entry", "image_base64": ""}
+    rec["_spooled_at"] = (spooled_at or datetime.now()).isoformat()
+    # timestamped name so sorted() == oldest-first
+    fname = f"anpr_{datetime.now().strftime('%Y%m%d_%H%M%S_%f')}_{plate}.json"
+    with open(os.path.join(d, fname), "w", encoding="utf-8") as fh:
+        json.dump(rec, fh)
+
+
+class TestDrain:
+    @pytest.mark.asyncio
+    async def test_all_delivered_are_removed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_spool(tmp, "AAA")
+            _write_spool(tmp, "BBB")
+            with patch.object(cbc, "settings", _settings(tmp)), \
+                 patch.object(cbc.httpx, "AsyncClient",
+                              _client_factory(_FakeResp(200), _FakeResp(201))):
+                await cbc.drain_pms_forward_spool()
+            assert _spool_files(tmp) == []
+
+    @pytest.mark.asyncio
+    async def test_retry_stops_and_leaves_the_rest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_spool(tmp, "AAA")
+            _write_spool(tmp, "BBB")
+            # First delivers, second says VA is down → drain stops, one remains.
+            with patch.object(cbc, "settings", _settings(tmp)), \
+                 patch.object(cbc.httpx, "AsyncClient",
+                              _client_factory(_FakeResp(200),
+                                              httpx.ConnectError("down"))):
+                await cbc.drain_pms_forward_spool()
+            assert len(_spool_files(tmp)) == 1
+
+    @pytest.mark.asyncio
+    async def test_poison_4xx_is_removed_not_wedged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_spool(tmp, "AAA")  # oldest — VA rejects permanently
+            _write_spool(tmp, "BBB")  # must still be delivered behind it
+            with patch.object(cbc, "settings", _settings(tmp)), \
+                 patch.object(cbc.httpx, "AsyncClient",
+                              _client_factory(_FakeResp(400, "bad"), _FakeResp(200))):
+                await cbc.drain_pms_forward_spool()
+            assert _spool_files(tmp) == []
+
+    @pytest.mark.asyncio
+    async def test_stale_payload_dropped_without_delivery(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_spool(tmp, "OLD",
+                         spooled_at=datetime.now() - timedelta(seconds=99999))
+            # No outcome supplied: if the drain tried to POST it, next() would
+            # raise StopIteration and fail the test — proving it never delivered.
+            with patch.object(cbc, "settings", _settings(tmp, max_age=3600.0)), \
+                 patch.object(cbc.httpx, "AsyncClient", _client_factory()):
+                await cbc.drain_pms_forward_spool()
+            assert _spool_files(tmp) == []


### PR DESCRIPTION
B1: decouple the VA forward from occupancy suppression in _flush_entry_burst. dedup and anti-bounce now set suppress_occupancy (skipping the EntryExitLog row, open session, and UC4 alert) but the notify_pms_anpr("entry") forward and the CAM-23/CAM-03 confirm-snapshot forwards run UNCONDITIONALLY. VA has its own dedup and needs the image to build the car's ReID identity + on-disk folder — this is the root cause of a suppressed entry leaving a car with no VA folder.

B2: make the VA forward durable. _deliver_anpr_payload does one attempt and returns ok / drop (4xx, never retryable) / retry (connect error / 5xx) — no inline retry loop, so the awaited webhook never blocks when VA is down. notify_pms_anpr spools to disk on retry; a background drainer (drain_pms_forward_spool, registered in main.py) re-POSTs oldest-first, removing on ok/drop and stopping only on retry, with a stale-age cap. New config: PMS_FORWARD_SPOOL_DIR / DRAIN_INTERVAL_SECONDS / SPOOL_MAX_AGE_SECONDS.

Tests: test_entry_suppression_forward.py (suppression still forwards); test_pms_forward_reliability.py (tri-state delivery, spool policy, drain).