### PR TITLE
fix(uc1): rescue entry ANPR dropped as UNKNOWN behind gateway NAT

### DIFF
--- a/app/services/event_dispatcher.py
+++ b/app/services/event_dispatcher.py
@@ -1,6 +1,8 @@
 # app/services/event_dispatcher.py
 """Routes events to correct use-case handlers — Phase 1 and Phase 2."""
 
+import time
+
 from app.services.event_parser import ParsedCameraEvent
 from app.services.occupancy_service import handle_occupancy_event
 from app.services.entry_exit_service import handle_anpr_event
@@ -12,6 +14,56 @@ from app.config import settings
 from sqlalchemy.orm import Session
 
 logger = get_logger(__name__)
+
+
+# ── ANPR gate-identity rescue ────────────────────────────────────────────────
+# The entry LPR fires a `vehicleMatchResult` (which resolves to the gate camera)
+# ~1-5s BEFORE the follow-on `ANPR`. On setups where every camera pushes through
+# a gateway/NAT, that follow-on ANPR can arrive with an unresolvable identity
+# (camera_id = "UNKNOWN-<gateway-ip>") because its body carries no mapped
+# ipAddress/deviceSerial — handle_anpr_event then drops it for "no gate", so no
+# entry is ever logged. We bridge the gap: remember the gate camera the paired
+# vehicleMatchResult resolved to, keyed by plate, and let the follow-on ANPR
+# inherit it. Bounded by ANPR_BURST_MAX_SECONDS so a stale hint can never
+# mislabel a later car. Per-process, like the entry burst buffer it feeds.
+_VMR_GATE_HINTS: dict[str, tuple[str, str, float]] = {}
+
+
+def _remember_vmr_gate(event: ParsedCameraEvent) -> None:
+    """Record plate → (camera_id, gate) when a vehicleMatchResult resolved to a
+    known gate camera, so a follow-on UNKNOWN ANPR can inherit the identity."""
+    gate = settings.CAMERAS.get(event.camera_id, {}).get("gate")
+    if gate not in ("entry", "exit") or not event.plate_number:
+        return
+    now = time.monotonic()
+    # Opportunistically prune expired hints so the dict stays bounded.
+    for plate in [p for p, (_, _, dl) in _VMR_GATE_HINTS.items() if dl <= now]:
+        _VMR_GATE_HINTS.pop(plate, None)
+    _VMR_GATE_HINTS[event.plate_number] = (
+        event.camera_id, gate, now + settings.ANPR_BURST_MAX_SECONDS,
+    )
+
+
+def _rescue_unknown_gate(event: ParsedCameraEvent) -> None:
+    """If an ANPR resolved to an UNKNOWN camera but a recent vehicleMatchResult
+    for the same plate resolved to a gate camera, adopt that identity so the
+    entry/exit isn't dropped. Only rescues UNKNOWN cameras — never overrides an
+    already-resolved one."""
+    if not event.plate_number or not str(event.camera_id).startswith("UNKNOWN"):
+        return
+    hint = _VMR_GATE_HINTS.get(event.plate_number)
+    if not hint:
+        return
+    camera_id, gate, deadline = hint
+    if time.monotonic() > deadline:
+        _VMR_GATE_HINTS.pop(event.plate_number, None)
+        return
+    logger.info(
+        "[dispatch] Rescued ANPR %s → %s (gate=%s) via recent vehicleMatchResult "
+        "for plate=%s", event.camera_id, camera_id, gate, event.plate_number,
+    )
+    event.camera_id = camera_id
+    event.gate = gate
 
 async def dispatch_event(event: ParsedCameraEvent, db: Session) -> dict:
     """
@@ -65,12 +117,21 @@ async def dispatch_event(event: ParsedCameraEvent, db: Session) -> dict:
         # don't process it here — see SNAPSHOT_EVENT_TYPES comment above. Just
         # log at DEBUG so we can confirm the camera fired it but we ignored it.
         if event.event_type == "vehicleMatchResult":
+            # Not processed here, but remember which gate camera it resolved to so
+            # the follow-on ANPR can inherit the identity if it arrives UNKNOWN.
+            _remember_vmr_gate(event)
             logger.debug(
                 "[dispatch] Skipping vehicleMatchResult from %s plate=%s — "
                 "follow-on ANPR event will carry the multipart image",
                 event.camera_id, event.plate_number,
             )
             return
+
+        # Rescue an ANPR whose identity didn't resolve (UNKNOWN-<gateway-ip>) by
+        # inheriting the gate from the paired vehicleMatchResult seen moments ago.
+        # Done before the gate/feed logic below so the whole flow sees the real id.
+        if event.event_type in ("ANPR", "AccessControllerEvent"):
+            _rescue_unknown_gate(event)
 
         is_gate = settings.CAMERAS.get(event.camera_id, {}).get("gate") in ("entry", "exit")
         is_occupancy_event = event.event_type == "linedetection"

--- a/tests/test_event_dispatcher.py
+++ b/tests/test_event_dispatcher.py
@@ -9,8 +9,26 @@ import pytest
 from datetime import datetime, UTC
 from unittest.mock import MagicMock, AsyncMock, patch
 
+import app.services.event_dispatcher as dispatcher
 from app.services.event_dispatcher import dispatch_event
 from app.services.event_parser import ParsedCameraEvent
+
+
+def make_anpr_event(cam_id, plate, event_type="ANPR"):
+    return ParsedCameraEvent(
+        camera_id=cam_id,
+        device_serial="x",
+        channel_id=1,
+        event_type=event_type,
+        detection_target="vehicle",
+        region_id=None,
+        channel_name="lpr",
+        trigger_time=datetime.now(UTC),
+        raw_xml="{}",
+        snapshot_path="snap.jpg",          # set → skips the ISAPI snapshot fetch
+        local_snapshot_path="snap.jpg",
+        plate_number=plate,
+    )
 
 
 def make_line_event(cam_id, direction="forward", region_id="1"):
@@ -86,3 +104,69 @@ async def test_occupancy_confirm_cam_not_double_confirmed(mock_settings, mock_co
 
     mock_occ.assert_awaited_once()        # handled by the occupancy path
     mock_confirm.assert_not_awaited()     # not double-confirmed here
+
+
+def _configure_anpr(mock_settings, cameras):
+    mock_settings.CAMERAS = cameras
+    mock_settings.ANPR_BURST_MAX_SECONDS = 20.0
+    mock_settings.LOG_CAMERA_FILTER = ""
+    mock_settings.LOG_CAMERA_EXCLUDE = ""
+    mock_settings.ENTRY_CONFIRM_CAMERAS = ""
+
+
+@pytest.mark.asyncio
+@patch("app.services.event_dispatcher.handle_anpr_event", new_callable=AsyncMock)
+@patch("app.services.event_dispatcher.add_event_to_feed")
+@patch("app.services.event_dispatcher.settings")
+async def test_unknown_anpr_rescued_by_prior_vmr(mock_settings, mock_feed, mock_anpr):
+    """A vehicleMatchResult resolves the entry camera; the follow-on ANPR arrives
+    UNKNOWN (gateway NAT). The ANPR must inherit CAM-ENTRY so it isn't dropped."""
+    dispatcher._VMR_GATE_HINTS.clear()
+    _configure_anpr(mock_settings, {"CAM-ENTRY": {"gate": "entry"}})
+
+    # 1) entry LPR fires the imageless match result — resolves to CAM-ENTRY
+    await dispatch_event(make_anpr_event("CAM-ENTRY", "DJS-7842", "vehicleMatchResult"), MagicMock())
+    mock_anpr.assert_not_awaited()        # VMR itself is not processed
+
+    # 2) follow-on ANPR arrives with an unresolvable identity
+    await dispatch_event(make_anpr_event("UNKNOWN-10.1.20.60", "DJS-7842"), MagicMock())
+
+    mock_anpr.assert_awaited_once()
+    rescued = mock_anpr.await_args.args[0]
+    assert rescued.camera_id == "CAM-ENTRY"
+    assert rescued.gate == "entry"
+
+
+@pytest.mark.asyncio
+@patch("app.services.event_dispatcher.handle_anpr_event", new_callable=AsyncMock)
+@patch("app.services.event_dispatcher.add_event_to_feed")
+@patch("app.services.event_dispatcher.settings")
+async def test_unknown_anpr_without_vmr_not_rescued(mock_settings, mock_feed, mock_anpr):
+    """No prior vehicleMatchResult for the plate → the UNKNOWN ANPR is left as-is
+    (handle_anpr_event will drop it for 'no gate'), never misattributed."""
+    dispatcher._VMR_GATE_HINTS.clear()
+    _configure_anpr(mock_settings, {"CAM-ENTRY": {"gate": "entry"}})
+
+    await dispatch_event(make_anpr_event("UNKNOWN-10.1.20.60", "GHOST-0001"), MagicMock())
+
+    # still dispatched (handler decides), but identity untouched
+    rescued = mock_anpr.await_args.args[0]
+    assert rescued.camera_id == "UNKNOWN-10.1.20.60"
+    assert rescued.gate is None
+
+
+@pytest.mark.asyncio
+@patch("app.services.event_dispatcher.handle_anpr_event", new_callable=AsyncMock)
+@patch("app.services.event_dispatcher.add_event_to_feed")
+@patch("app.services.event_dispatcher.settings")
+async def test_resolved_anpr_not_overridden(mock_settings, mock_feed, mock_anpr):
+    """An ANPR that already resolved (CAM-EXIT) is never rewritten, even if a VMR
+    hint exists for the same plate."""
+    dispatcher._VMR_GATE_HINTS.clear()
+    _configure_anpr(mock_settings, {"CAM-ENTRY": {"gate": "entry"}, "CAM-EXIT": {"gate": "exit"}})
+
+    await dispatch_event(make_anpr_event("CAM-ENTRY", "SHR-5918", "vehicleMatchResult"), MagicMock())
+    await dispatch_event(make_anpr_event("CAM-EXIT", "SHR-5918"), MagicMock())
+
+    rescued = mock_anpr.await_args.args[0]
+    assert rescued.camera_id == "CAM-EXIT"    # untouched — was already resolved


### PR DESCRIPTION
When all cameras push through the gateway (source IP 10.1.20.60), the entry LPR follow-on ANPR body carries no mapped ipAddress/deviceSerial and resolves to UNKNOWN-<gateway-ip>, so handle_anpr_event drops it for "no gate" and no entry is ever logged (every exit then reports "no matching entry").

The paired vehicleMatchResult ~1-5s earlier DOES resolve to the gate camera. Cache plate -> (camera_id, gate) from it (per-process, TTL=ANPR_BURST_MAX_SECONDS) and let a follow-on UNKNOWN ANPR of the same plate inherit that identity. Only rescues UNKNOWN cameras, never overrides a resolved one; topology-independent.