### PR TITLE
fix(uc1): rescue a misread entry ANPR by pairing it to its vehicleMat…

### DIFF
--- a/app/services/event_dispatcher.py
+++ b/app/services/event_dispatcher.py
@@ -28,6 +28,36 @@ logger = get_logger(__name__)
 # mislabel a later car. Per-process, like the entry burst buffer it feeds.
 _VMR_GATE_HINTS: dict[str, tuple[str, str, float]] = {}
 
+# THE PLATE-KEYED HINT ABOVE CANNOT RESCUE A MISREAD — the one case that matters.
+# It is WRITTEN under the vehicleMatchResult's plate and READ under the follow-on
+# ANPR's plate, so it only ever hits when the two agree. When the raw OCR
+# misreads, the lookup misses and the event is dropped for "no gate".
+#
+# Measured on production logs 2026-07-12..20: 292 VMR->ANPR pairs; 290 agreed and
+# were rescued; the 2 that disagreed were both RGR-6466, and both were lost:
+#
+#   06:35:10  vehicleMatchResult  CAM-ENTRY           RGR-6466   <- opened the barrier
+#   06:35:12  ANPR                UNKNOWN-10.1.20.60  66466RA    <- raw OCR, wrong
+#   06:35:12  [Phase2] Dropped ANPR event - no gate assigned
+#
+# That car stopped being recorded on 2026-07-16 while it kept parking every day,
+# because the BARRIER acts on the match result and we acted on the raw OCR.
+#
+# So keep a second, plate-INDEPENDENT trail of recent match results. When the
+# plate lookup misses, pair FIFO — a single-lane gate is ordered and the ANPR
+# trails its own VMR by 1-5s — and adopt the match result's PLATE as well as its
+# gate: it is the identity the access controller accepted, and the better string
+# (95% well-formed vs the raw OCR on the same feed). Entries are consumed on use
+# so two ANPRs can never claim one crossing.
+_VMR_RECENT: list[tuple[str, str, str, float]] = []  # (plate, camera_id, gate, deadline)
+
+
+def _prune_vmr(now: float) -> None:
+    """Drop expired hints from both stores. Bounded by ANPR_BURST_MAX_SECONDS."""
+    for plate in [p for p, (_, _, dl) in _VMR_GATE_HINTS.items() if dl <= now]:
+        _VMR_GATE_HINTS.pop(plate, None)
+    _VMR_RECENT[:] = [h for h in _VMR_RECENT if h[3] > now]
+
 
 def _remember_vmr_gate(event: ParsedCameraEvent) -> None:
     """Record plate → (camera_id, gate) when a vehicleMatchResult resolved to a
@@ -36,34 +66,59 @@ def _remember_vmr_gate(event: ParsedCameraEvent) -> None:
     if gate not in ("entry", "exit") or not event.plate_number:
         return
     now = time.monotonic()
-    # Opportunistically prune expired hints so the dict stays bounded.
-    for plate in [p for p, (_, _, dl) in _VMR_GATE_HINTS.items() if dl <= now]:
-        _VMR_GATE_HINTS.pop(plate, None)
-    _VMR_GATE_HINTS[event.plate_number] = (
-        event.camera_id, gate, now + settings.ANPR_BURST_MAX_SECONDS,
-    )
+    # Opportunistically prune expired hints so the stores stay bounded.
+    _prune_vmr(now)
+    deadline = now + settings.ANPR_BURST_MAX_SECONDS
+    _VMR_GATE_HINTS[event.plate_number] = (event.camera_id, gate, deadline)
+    _VMR_RECENT.append((event.plate_number, event.camera_id, gate, deadline))
 
 
 def _rescue_unknown_gate(event: ParsedCameraEvent) -> None:
     """If an ANPR resolved to an UNKNOWN camera but a recent vehicleMatchResult
-    for the same plate resolved to a gate camera, adopt that identity so the
-    entry/exit isn't dropped. Only rescues UNKNOWN cameras — never overrides an
-    already-resolved one."""
-    if not event.plate_number or not str(event.camera_id).startswith("UNKNOWN"):
+    resolved to a gate camera, adopt that identity so the entry/exit isn't
+    dropped. Only rescues UNKNOWN cameras — never overrides an already-resolved
+    one.
+
+    Two paths, in order:
+
+      1. exact plate — the common case (290/292 in production), unchanged;
+      2. FIFO fallback on the plate-independent trail, reached only when path 1
+         missed. A miss means the OCR disagrees with the string the barrier
+         accepted, so this path also OVERRIDES the plate.
+    """
+    if not str(event.camera_id).startswith("UNKNOWN"):
         return
-    hint = _VMR_GATE_HINTS.get(event.plate_number)
-    if not hint:
+    now = time.monotonic()
+    _prune_vmr(now)
+
+    # ── 1. exact plate ───────────────────────────────────────────────────────
+    hint = _VMR_GATE_HINTS.get(event.plate_number) if event.plate_number else None
+    if hint:
+        camera_id, gate, _ = hint
+        logger.info(
+            "[dispatch] Rescued ANPR %s -> %s (gate=%s) via recent "
+            "vehicleMatchResult for plate=%s",
+            event.camera_id, camera_id, gate, event.plate_number,
+        )
+        event.camera_id = camera_id
+        event.gate = gate
+        _VMR_RECENT[:] = [h for h in _VMR_RECENT if h[0] != event.plate_number]
         return
-    camera_id, gate, deadline = hint
-    if time.monotonic() > deadline:
-        _VMR_GATE_HINTS.pop(event.plate_number, None)
+
+    # ── 2. FIFO fallback — the misread case ──────────────────────────────────
+    if not _VMR_RECENT:
         return
-    logger.info(
-        "[dispatch] Rescued ANPR %s → %s (gate=%s) via recent vehicleMatchResult "
-        "for plate=%s", event.camera_id, camera_id, gate, event.plate_number,
+    vmr_plate, camera_id, gate, _ = _VMR_RECENT.pop(0)
+    logger.warning(
+        "[dispatch] Rescued ANPR %s -> %s (gate=%s) by FIFO vehicleMatchResult "
+        "pairing; the ANPR read %r disagrees with the match result %r — adopting "
+        "the match result (it is what opened the barrier)",
+        event.camera_id, camera_id, gate, event.plate_number, vmr_plate,
     )
     event.camera_id = camera_id
     event.gate = gate
+    event.plate_number = vmr_plate
+    _VMR_GATE_HINTS.pop(vmr_plate, None)
 
 async def dispatch_event(event: ParsedCameraEvent, db: Session) -> dict:
     """

--- a/tests/test_event_dispatcher.py
+++ b/tests/test_event_dispatcher.py
@@ -170,3 +170,121 @@ async def test_resolved_anpr_not_overridden(mock_settings, mock_feed, mock_anpr)
 
     rescued = mock_anpr.await_args.args[0]
     assert rescued.camera_id == "CAM-EXIT"    # untouched — was already resolved
+
+
+# ── Misread rescue (the RGR-6466 outage, 2026-07-16..20) ────────────────────
+# Production logs showed 292 vehicleMatchResult->ANPR pairs. 290 agreed and were
+# rescued by the plate-keyed hint. The 2 that DISAGREED were both this car, and
+# both were dropped — because the hint is written under the match result's plate
+# and read under the ANPR's misread one, so it can never hit when it matters:
+#
+#   06:35:10  vehicleMatchResult  CAM-ENTRY           RGR-6466
+#   06:35:12  ANPR                UNKNOWN-10.1.20.60  66466RA
+#   06:35:12  [Phase2] Dropped ANPR event - no gate assigned
+#
+# The car kept parking daily with no entry recorded, which left VA with no open
+# session, which left slot B12 permanently unidentified.
+
+
+@pytest.mark.asyncio
+@patch("app.services.event_dispatcher.handle_anpr_event", new_callable=AsyncMock)
+@patch("app.services.event_dispatcher.add_event_to_feed")
+@patch("app.services.event_dispatcher.settings")
+async def test_misread_anpr_rescued_and_plate_corrected(mock_settings, mock_feed, mock_anpr):
+    """The exact 2026-07-20 06:35 sequence: the ANPR misreads, so the plate-keyed
+    hint misses. The event must still be rescued, and must carry the match
+    result's plate — that is the string the barrier accepted."""
+    dispatcher._VMR_GATE_HINTS.clear()
+    dispatcher._VMR_RECENT.clear()
+    _configure_anpr(mock_settings, {"CAM-ENTRY": {"gate": "entry"}})
+
+    await dispatch_event(make_anpr_event("CAM-ENTRY", "RGR-6466", "vehicleMatchResult"), MagicMock())
+    await dispatch_event(make_anpr_event("UNKNOWN-10.1.20.60", "66466RA"), MagicMock())
+
+    mock_anpr.assert_awaited_once()
+    rescued = mock_anpr.await_args.args[0]
+    assert rescued.camera_id == "CAM-ENTRY"      # no longer dropped for "no gate"
+    assert rescued.gate == "entry"
+    assert rescued.plate_number == "RGR-6466"    # the barrier's plate wins, not '66466RA'
+
+
+@pytest.mark.asyncio
+@patch("app.services.event_dispatcher.handle_anpr_event", new_callable=AsyncMock)
+@patch("app.services.event_dispatcher.add_event_to_feed")
+@patch("app.services.event_dispatcher.settings")
+async def test_misread_with_no_plate_at_all_is_rescued(mock_settings, mock_feed, mock_anpr):
+    """The 2026-07-16 06:31 variant of the same failure: the follow-on ANPR
+    carried plate=None. Previously it returned before even looking at the hint."""
+    dispatcher._VMR_GATE_HINTS.clear()
+    dispatcher._VMR_RECENT.clear()
+    _configure_anpr(mock_settings, {"CAM-ENTRY": {"gate": "entry"}})
+
+    await dispatch_event(make_anpr_event("CAM-ENTRY", "RGR-6466", "vehicleMatchResult"), MagicMock())
+    await dispatch_event(make_anpr_event("UNKNOWN-10.1.20.60", None), MagicMock())
+
+    rescued = mock_anpr.await_args.args[0]
+    assert rescued.camera_id == "CAM-ENTRY"
+    assert rescued.plate_number == "RGR-6466"
+
+
+@pytest.mark.asyncio
+@patch("app.services.event_dispatcher.handle_anpr_event", new_callable=AsyncMock)
+@patch("app.services.event_dispatcher.add_event_to_feed")
+@patch("app.services.event_dispatcher.settings")
+async def test_exact_plate_match_does_not_consume_another_cars_hint(mock_settings, mock_feed, mock_anpr):
+    """Two cars in the queue. The second's ANPR agrees with its own match result,
+    so it must take the exact-plate path and leave car A's hint intact for A."""
+    dispatcher._VMR_GATE_HINTS.clear()
+    dispatcher._VMR_RECENT.clear()
+    _configure_anpr(mock_settings, {"CAM-ENTRY": {"gate": "entry"}})
+
+    await dispatch_event(make_anpr_event("CAM-ENTRY", "RGR-6466", "vehicleMatchResult"), MagicMock())
+    await dispatch_event(make_anpr_event("CAM-ENTRY", "DJS-7842", "vehicleMatchResult"), MagicMock())
+    # car B's ANPR reads correctly -> exact match, must NOT eat car A's hint
+    await dispatch_event(make_anpr_event("UNKNOWN-10.1.20.60", "DJS-7842"), MagicMock())
+    assert mock_anpr.await_args.args[0].plate_number == "DJS-7842"
+
+    # car A's ANPR misreads -> falls back, and A's hint is still there
+    await dispatch_event(make_anpr_event("UNKNOWN-10.1.20.60", "66466RA"), MagicMock())
+    assert mock_anpr.await_args.args[0].plate_number == "RGR-6466"
+
+
+@pytest.mark.asyncio
+@patch("app.services.event_dispatcher.handle_anpr_event", new_callable=AsyncMock)
+@patch("app.services.event_dispatcher.add_event_to_feed")
+@patch("app.services.event_dispatcher.settings")
+async def test_fifo_hint_is_consumed_once(mock_settings, mock_feed, mock_anpr):
+    """One crossing must not be claimed by two ANPRs — the second misread finds
+    no hint left and is passed through untouched rather than misattributed."""
+    dispatcher._VMR_GATE_HINTS.clear()
+    dispatcher._VMR_RECENT.clear()
+    _configure_anpr(mock_settings, {"CAM-ENTRY": {"gate": "entry"}})
+
+    await dispatch_event(make_anpr_event("CAM-ENTRY", "RGR-6466", "vehicleMatchResult"), MagicMock())
+    await dispatch_event(make_anpr_event("UNKNOWN-10.1.20.60", "66466RA"), MagicMock())
+    assert mock_anpr.await_args.args[0].plate_number == "RGR-6466"
+
+    await dispatch_event(make_anpr_event("UNKNOWN-10.1.20.60", "66466XA"), MagicMock())
+    stray = mock_anpr.await_args.args[0]
+    assert stray.camera_id == "UNKNOWN-10.1.20.60"   # not rescued
+    assert stray.plate_number == "66466XA"           # not rewritten
+
+
+@pytest.mark.asyncio
+@patch("app.services.event_dispatcher.handle_anpr_event", new_callable=AsyncMock)
+@patch("app.services.event_dispatcher.add_event_to_feed")
+@patch("app.services.event_dispatcher.settings")
+async def test_expired_hint_never_rescues(mock_settings, mock_feed, mock_anpr):
+    """A stale match result must not label a later car. Bounded by
+    ANPR_BURST_MAX_SECONDS in BOTH stores."""
+    dispatcher._VMR_GATE_HINTS.clear()
+    dispatcher._VMR_RECENT.clear()
+    _configure_anpr(mock_settings, {"CAM-ENTRY": {"gate": "entry"}})
+    mock_settings.ANPR_BURST_MAX_SECONDS = 0.0     # every hint is born expired
+
+    await dispatch_event(make_anpr_event("CAM-ENTRY", "RGR-6466", "vehicleMatchResult"), MagicMock())
+    await dispatch_event(make_anpr_event("UNKNOWN-10.1.20.60", "66466RA"), MagicMock())
+
+    stray = mock_anpr.await_args.args[0]
+    assert stray.camera_id == "UNKNOWN-10.1.20.60"
+    assert stray.plate_number == "66466RA"


### PR DESCRIPTION
…chResult

The entry LPR fires vehicleMatchResult (the plate the barrier accepted) 1-5s before the follow-on ANPR (raw OCR), which arrives with an unresolvable identity behind the gateway NAT. _rescue_unknown_gate bridges that gap — but the hint was WRITTEN under the match result's plate and READ under the ANPR's plate, so it could only ever hit when the two agreed. It was structurally incapable of rescuing a misread, which is the only case it exists for.

Measured on production logs 2026-07-12..20: 292 VMR->ANPR pairs; 290 agreed and were rescued; the 2 that disagreed were both RGR-6466 and both were dropped:

  06:35:10  vehicleMatchResult  CAM-ENTRY           RGR-6466
  06:35:12  ANPR                UNKNOWN-10.1.20.60  66466RA
  06:35:12  [Phase2] Dropped ANPR event - no gate assigned

That car stopped being recorded on 2026-07-16 while it kept parking every morning. With no entry there is no open parking_session, so Video Analytics had no candidate to confirm against and slot B12 stayed permanently unidentified — even though its slot camera reads the plate correctly on every attempt.

Adds a second, plate-INDEPENDENT trail of recent match results. The exact-plate path is unchanged (the 290 working cases). When it misses — which means the OCR disagrees with the string that opened the barrier — we pair FIFO (a single-lane gate is ordered) and adopt the match result's plate as well as its gate. Hints are consumed on use so one crossing cannot be claimed twice, and both stores expire on ANPR_BURST_MAX_SECONDS so a stale result cannot label a later car.

Tests replay the exact production sequences (06:35 misread, 06:31 plate=None), plus queue ordering, single-consumption and expiry. 115/115 pass.


Claude-Session: https://claude.ai/code/session_01Ke7ymM9awa9woWmRCqgcci